### PR TITLE
Update help, add clear().

### DIFF
--- a/source/microbit/help.c
+++ b/source/microbit/help.c
@@ -35,7 +35,7 @@ STATIC const char *help_text =
 "Be brave! Break things! Learn and have fun! :-)\n"
 "\n"
 "Type 'import microbit', press return and try these commands:\n"
-"  microbit.display.scroll_string('Hello')\n"
+"  microbit.display.scroll('Hello')\n"
 "  microbit.system_time()\n"
 "  microbit.sleep(1000)\n"
 "  microbit.button_a.is_pressed()\n"

--- a/source/microbit/microbitdisplay.cpp
+++ b/source/microbit/microbitdisplay.cpp
@@ -101,11 +101,18 @@ mp_obj_t microbit_display_scroll(mp_uint_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(microbit_display_scroll_obj, 2, 3, microbit_display_scroll);
 
+mp_obj_t microbit_display_clear(void) {
+    uBit.display.clear();
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_display_clear_obj, microbit_display_clear);
+
 STATIC const mp_map_elem_t microbit_display_locals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_image), (mp_obj_t)&microbit_image_obj },
 
     { MP_OBJ_NEW_QSTR(MP_QSTR_print), (mp_obj_t)&microbit_display_print_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_scroll), (mp_obj_t)&microbit_display_scroll_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_clear), (mp_obj_t)&microbit_display_clear_obj },
 };
 
 STATIC MP_DEFINE_CONST_DICT(microbit_display_locals_dict, microbit_display_locals_dict_table);


### PR DESCRIPTION
This branch introduces two changes (and a tacet opportunity to familiarise myself with how MicroPython works in conjunction with the micro:bit DAL):
- Updated the help() function to reference `microbit.display.scroll` rather than `microbit.display.scroll_string`.
- Included the `clear` function into the `microbit.display` object.

It compiles and appears to work. Not sure what the modus operandi is for testing such things given that this is basically plumbing between the DAL -> MicroPython.
