### PR TITLE
Add hex/python combiner to tools

### DIFF
--- a/tools/hexlifyscript.py
+++ b/tools/hexlifyscript.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     parser.add_argument('-a', '--address', type=int, help='Start address for the python script', default=0x3e000)
 
     # this is only useful if you're merging.
-    parser.add_argument('-m', '--merge', nargs='?', type=argparse.FileType('rb'), help='micropython hex file to merge with', default=os.devnull)
+    parser.add_argument('-m', '--merge', nargs='?', type=argparse.FileType('rt'), help='micropython hex file to merge with', default=os.devnull)
 
     args = parser.parse_args()
 
@@ -31,4 +31,5 @@ if __name__ == "__main__":
 
     base_hex.merge(python_hex, overlap='error')
 
-    base_hex.write_hex_file(args.output)
+    base_hex.tobinfile(args.output)
+


### PR DESCRIPTION
This is an easy to use tool, which lets you merge a python file with a hex file without needing upyed.

It also leads to the quite nice to use set of commands:

``` bash
./tools/makecombinedhex.py build/bbc-microbit-classic-gcc-nosd/source/microbit-micropython.hex examples/tune.py
cp build/bbc-microbit-classic-gcc-nosd/source/microbit-micropython.combined.hex /Volumes/MICROBIT/
picocom /dev/tty.usbmodem1422 -b 115200
```

which is really useful for quickly iterating a python script.
