### PR TITLE
Use frozen modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/*
 yotta_modules/*
 yotta_targets/*
 *.swp
+frozen*

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,15 @@ HEX_FINAL = build/firmware.hex
 
 all: yotta
 
-yotta: inc/genhdr/qstrdefs.generated.h
+yotta: inc/genhdr/qstrdefs.generated.h frozen
 	@yt build
 	@/bin/cp $(HEX_SRC) $(HEX_FINAL)
+
+frozen:
+	@tools/make-frozen.py pylibs > source/microbit/frozenlibs.c
+
+clean:
+	@yt clean
 
 # Note: we need to protect the qstr names from the preprocessor, so we wrap
 # the lines in "" and then unwrap after the preprocessor is finished.

--- a/examples/tune.py
+++ b/examples/tune.py
@@ -1,61 +1,7 @@
 # this demo requires a speaker connected to P0 and GND
 
 import microbit
-
-class Tune:
-    # 1,000,000/frequncy
-    NOTES = {
-        'C':  3822,
-        'C#': 3608,
-        'D':  3405,
-        'D#': 3214,
-        'E':  3034,
-        'F':  2863,
-        'F#': 2703,
-        'G':  2551,
-        'G#': 2408,
-        'A':  2273,
-        'A#': 2145,
-        'B':  2025,
-    }
-
-    ALIASES = {
-        'Db': 'C#',
-        'Eb': 'D#',
-        'Gb': 'F#',
-        'Ab': 'G#',
-        'Bb': 'A#'
-    }
-
-    def __init__(self, pin, bpm=180):
-        self.pin = pin
-        self.bpm = bpm
-
-        self.notes = []
-        # (1/frequency (in us), time)
-
-    def play(self):
-        self.pin.set_analog_value(100)
-
-        for i, note in enumerate(self.notes):
-            print("playing note %i of %i" % (i, len(self.notes)))
-
-            period, length = note
-
-            self.pin.set_analog_period_us(period)
-
-            microbit.sleep(length * (60000//self.bpm))
-
-    def stop(self):
-        self.pin.set_analog_value(0)
-
-    def add_note(self, note, length, octave = 0):
-        if note in Tune.ALIASES:
-            # this allows us to treat flats as sharps
-            note = Tune.ALIASES[note]
-
-        self.notes.append((Tune.NOTES[note] // (2 ** octave), length))
-
+from music import Tune
 
 # play a C Major scale
 tune = Tune(microbit.io.P0)

--- a/inc/microbit/mpconfigport.h
+++ b/inc/microbit/mpconfigport.h
@@ -44,7 +44,7 @@
 #define MICROPY_PY_STRUCT           (1)
 #define MICROPY_PY_SYS              (1)
 #define MICROPY_PY_SYS_PLATFORM     "microbit"
-#define MICROPY_MODULE_FROZEN       (0)
+#define MICROPY_MODULE_FROZEN       (1)
 #define MICROPY_CPYTHON_COMPAT      (0)
 #define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_MPZ)
 #define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_FLOAT)

--- a/pylibs/music.py
+++ b/pylibs/music.py
@@ -1,0 +1,108 @@
+# accompanying demo in examples
+
+import microbit
+
+class Tune:
+    # 1,000,000/frequncy
+    NOTES = {
+        'C':  3822,
+        'C#': 3608,
+        'D':  3405,
+        'D#': 3214,
+        'E':  3034,
+        'F':  2863,
+        'F#': 2703,
+        'G':  2551,
+        'G#': 2408,
+        'A':  2273,
+        'A#': 2145,
+        'B':  2025,
+        None: 0
+    }
+
+    ALIASES = {
+        'Db': 'C#',
+        'Eb': 'D#',
+        'Gb': 'F#',
+        'Ab': 'G#',
+        'Bb': 'A#'
+    }
+
+    def __init__(self, pin, bpm=180, notes=[]):
+        self.pin = pin
+        self.bpm = bpm
+
+        self._notes = []
+        self.add_notes(notes)
+        # (1/frequency (in us), time)
+
+    def play(self):
+        self.pin.set_analog_value(100)
+
+        for i, note in enumerate(self._notes):
+            print("playing note %i of %i" % (i, len(self._notes)))
+
+            period, length = note
+
+            self.pin.set_analog_period_us(int(period))
+
+            microbit.sleep(int(length * (60000//self.bpm)))
+
+        self.stop()
+
+    def stop(self):
+        self.pin.set_analog_value(0)
+
+    def add_note(self, note, length, octave = 0):
+        if note in Tune.ALIASES:
+            # this allows us to treat flats as sharps
+            note = Tune.ALIASES[note]
+
+        self._notes.append((Tune.NOTES[note] // (2 ** octave), length))
+
+    def add_notes(self, notes):
+        for note in notes:
+            # the tuples in note can be just like the args of add_note
+            self.add_note(*note)
+
+HAPPY_BIRTHDAY = [
+    ('C', 0.75),
+    (None, 0.05), # so you can distinguish the two C's
+    ('C', 0.25),
+    ('D', 1),
+    ('C', 1),
+    ('F', 1),
+    ('E', 2),
+    ('C', 0.75),
+    (None, 0.05), # so you can distinguish the two C's
+    ('C', 0.25),
+    ('D', 1),
+    ('C', 1),
+    ('G', 1),
+    ('F', 2),
+    ('C', 0.75),
+    (None, 0.05), # so you can distinguish the two C's
+    ('C', 0.25),
+    ('C', 1, 1), # an octave above middle C :)
+    ('A', 1),
+    ('F', 1),
+    ('E', 1),
+    ('D', 2), # unfortunately we don't have pauses yet ;)
+    ('Bb', 0.75),
+    (None, 0.05),
+    ('Bb', 0.25),
+    ('A', 1),
+    ('F', 1),
+    ('G', 1),
+    ('F', 3),
+    (None,3),
+    ('F', 1),
+    ('C',0.33333),
+    ('B',0.33333, -1),
+    ('C',0.33333),
+    ('C#',1),
+    ('C',1),
+    (None,1),
+    ('E',1),
+    ('F',1)
+]

--- a/tools/make-frozen.py
+++ b/tools/make-frozen.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+#
+# Create frozen modules structure for MicroPython.
+#
+# Usage:
+#
+# Have a directory with modules to be frozen (only modules, not packages
+# supported so far):
+#
+# frozen/foo.py
+# frozen/bar.py
+#
+# Run script, passing path to the directory above:
+#
+# ./make-frozen.py frozen > frozen.c
+#
+# Include frozen.c in your build, having defined MICROPY_MODULE_FROZEN in
+# config.
+#
+from __future__ import print_function
+import sys
+import os
+
+
+def module_name(f):
+    return f[:-len(".py")]
+
+modules = []
+
+root = sys.argv[1].rstrip("/")
+root_len = len(root)
+
+for dirpath, dirnames, filenames in os.walk(root):
+    for f in filenames:
+        fullpath = dirpath + "/" + f
+        st = os.stat(fullpath)
+        modules.append((fullpath[root_len + 1:], st))
+
+print("#include <stdint.h>")
+print("const uint16_t mp_frozen_sizes[] = {")
+
+for f, st in modules:
+    print("%d," % st.st_size)
+
+print("0};")
+
+print("const char mp_frozen_content[] = {")
+for f, st in modules:
+    m = module_name(f)
+    print('"%s\\0"' % m)
+    data = open(sys.argv[1] + "/" + f, "rb").read()
+    # Python2 vs Python3 tricks
+    data = repr(data)
+    if data[0] == "b":
+        data = data[1:]
+    data = data[1:-1]
+    data = data.replace('"', '\\"')
+    print('"%s"' % data)
+print("};")


### PR DESCRIPTION
This should allow us to build a library of python code, which can be easily imported. I would imagine that @dpgeorge may have a reason for not using frozen libraries, in which case we can use some other method, however this seemed like a sensible way to me.

This includes a music module, which can be used as shown in the updated tune example.
