### PR TITLE
Add Matthew to the author credits

### DIFF
--- a/source/microbit/modthis.cpp
+++ b/source/microbit/modthis.cpp
@@ -56,7 +56,7 @@ STATIC mp_obj_t this_authors(void) {
     */
     STATIC const char *authors_text =
 "MicroPython on the micro:bit is brought to you by:\n"
-"Damien P.George and Nicholas H.Tollervey\n";
+"Damien P.George, Matthew Else and Nicholas H.Tollervey.\n";
     mp_printf(&mp_plat_print, "%s", authors_text);
     return mp_const_none;
 }


### PR DESCRIPTION
This branch adds Matthew Else to the author credits.

This PR could also be used as a template for others who have had code accepted into the micro:bit version of MicroPython.

@matthewelse I presume this is OK..?
