### PR TITLE
Add a general info docstring to compass example #59

### DIFF
--- a/examples/compass.py
+++ b/examples/compass.py
@@ -4,7 +4,7 @@
 
     Creates a compass.
 
-    To calibrate the compass, lie it flat and spin it horizontally. For best
+    To calibrate the compass, lay it flat and spin it horizontally. For best
     results during calibration, try not to tilt the compass up and down.
 """
 from microbit import *

--- a/examples/compass.py
+++ b/examples/compass.py
@@ -1,7 +1,16 @@
+"""
+    compass.py
+    ~~~~~~~~~~
+
+    Creates a compass.
+
+    To calibrate the compass, lie it flat and spin it horizontally. For best
+    results during calibration, try not to tilt the compass up and down.
+"""
 from microbit import *
 
 needles = (Image.CLOCK12, Image.CLOCK1, Image.CLOCK2, Image.CLOCK3,
-           Image.CLOCK4, Image.CLOCK5, Image.CLOCK6, Image.CLOCK7, 
+           Image.CLOCK4, Image.CLOCK5, Image.CLOCK6, Image.CLOCK7,
            Image.CLOCK8, Image.CLOCK9, Image.CLOCK10, Image.CLOCK11)
 
 # You need to spin the microbit about a few times to help calibrate the compass


### PR DESCRIPTION
This adds a user friendly docstring to the top of the compass example (nicely done @markshannon) #59 #54. 

As an FYI, it follows the clean style of the Flask and Requests projects.

Minor change: removed a trailing space