### PR TITLE
Rename music_api to match the rest of docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ Contents:
    api_design_heuristics.rst
    microbit_micropython_api.rst
    microbit.rst
-   music_api.rst
+   music.rst
    compass.rst
 
 

--- a/docs/microbit.rst
+++ b/docs/microbit.rst
@@ -71,7 +71,7 @@ Modules
     :maxdepth: 1
 
     display.rst
-    music_api.rst
+    music.rst
     uart.rst
     i2c.rst
     accelerometer.rst

--- a/docs/music.rst
+++ b/docs/music.rst
@@ -1,13 +1,14 @@
-Music API
-*********
+Music
+*****
 
 .. py:module:: music
 
-This is the music API - we plan to start with an implementation that is purely
-blocking, as a proof of concept, and then add the wait parameter.
+This is the ``music`` module. You can use it to play simple tunes, provided
+that you connect a speaker to your board.
 
-Musical DSL
-===========
+
+Musical Notation
+================
 
 An individual note is specified thus::
 
@@ -39,6 +40,7 @@ page about scientific pitch notation`_.  For example, middle "C" is ``'c4'`` and
 concert "A" (440) is ``'a4'``. Octaves start on the note "C".
 
 .. _on this page about scientific pitch notation: https://en.wikipedia.org/wiki/Scientific_pitch_notation#Table_of_note_frequencies
+
 
 Functions
 =========


### PR DESCRIPTION
Also making some small changes in the text:

* remove a note about future plans for the module
* replace "DSL" with "Notation", may be easier to understand