### PR TITLE
Use fileinput in the hexlify script

### DIFF
--- a/tools/hexlifyscript.py
+++ b/tools/hexlifyscript.py
@@ -6,11 +6,13 @@ end of the MicroPython firmware.hex.  A simple header is added to the
 script.
 
 To execute from command line: ./hexlifyscript.py <script.py>
+It also accepts data on standard input.
 '''
 
-import sys
 import struct
 import binascii
+import fileinput
+
 
 SCRIPT_ADDR = 0x3e000 # magic start address in flash of script
 
@@ -37,5 +39,5 @@ def hexlify_script(script):
 
 if __name__ == '__main__':
     # read script from a file and print out the hexlified version
-    with open(sys.argv[1], 'rb') as f:
-        print(hexlify_script(f.read()))
+    with fileinput.input(mode='rb') as lines:
+        print(hexlify_script(b''.join(lines)))


### PR DESCRIPTION
So that the file can be either specified as the argument, or fed on the stdin.