### PR TITLE
Remove bpm, ticks from music.reset()

### DIFF
--- a/docs/music.rst
+++ b/docs/music.rst
@@ -105,8 +105,6 @@ Functions
 
     Resets the state of the following attributes in the following way:
 
-        * ``ticks = 4``
-        * ``bpm = 120``
         * ``duration = 4``
         * ``octave = 4``
 

--- a/source/microbit/microbitmusic.cpp
+++ b/source/microbit/microbitmusic.cpp
@@ -226,8 +226,6 @@ STATIC uint32_t start_note(const char *note_str, size_t note_len, MicroBitPin *p
 }
 
 STATIC mp_obj_t microbit_music_reset(void) {
-    music_state.bpm = DEFAULT_BPM;
-    music_state.ticks = DEFAULT_TICKS;
     music_state.last_octave = DEFAULT_OCTAVE;
     music_state.last_duration = DEFAULT_DURATION;
 


### PR DESCRIPTION
Following Damien's proposal this patch simply removes bpm and ticks from the music.reset() function. Therefore, any changes made using set_tempo() will be reflected when the next tune is played.