### PR TITLE
reset only octave and duration to defaults before play()

### DIFF
--- a/docs/music.rst
+++ b/docs/music.rst
@@ -74,8 +74,8 @@ Functions
     the musical DSL, above) then they are played one after the other to perform
     a melody.
 
-    In both cases, the ``reset`` method (see below) is tacitly called before
-    the music (whatever it may be) is played.
+    In both cases, the ``duration`` and ``octave`` values are reset to
+    their defaults before the music (whatever it may be) is played.
 
     An optional argument to specify the output pin can be used to override the
     default of ``microbit.pin0``.

--- a/source/microbit/microbitmusic.cpp
+++ b/source/microbit/microbitmusic.cpp
@@ -273,8 +273,9 @@ STATIC mp_obj_t microbit_music_play(mp_uint_t n_args, const mp_obj_t *pos_args, 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    // reset state so tunes always play the same
-    microbit_music_reset();
+    // reset octave and duration so tunes always play the same
+    music_state.last_octave = DEFAULT_OCTAVE;
+    music_state.last_duration = DEFAULT_DURATION;
 
     // get either a single note or a list of notes
     mp_uint_t len;


### PR DESCRIPTION
Reset only duration and octave in music.play() to allow different tempos.