### PR TITLE
Update module.json to point to microbit-dal version 1.4.6.

### DIFF
--- a/module.json
+++ b/module.json
@@ -10,7 +10,7 @@
     "mbed-classic": "~0.0.4",
     "ble": "lancaster-university/BLE_API#v2.1.11",
     "ble-nrf51822": "lancaster-university/nRF51822#v2.2.5",
-    "microbit-dal":"lancaster-university/microbit-dal#v1.4.2"
+    "microbit-dal":"lancaster-university/microbit-dal#v1.4.6"
   },
   "extraIncludes":[
     "inc",


### PR DESCRIPTION
This updates the dependencies to use the latest version of the DAL.

v1.4.6 brings:
- gestures
- fix to pwm
- fix to touch pins deinitialising
- servo API on pins
- compass auto-calibration

Some of these fix bug for us, some we need to expose at the Python level.