### PR TITLE
Allow microbit.sleep function to take a floating point number.

### DIFF
--- a/docs/microbit.rst
+++ b/docs/microbit.rst
@@ -27,7 +27,8 @@ Functions
 
         microbit.sleep(1000)
 
-    will pause the execution for one second.
+    will pause the execution for one second.  ``n`` can be an integer or
+    a floating point number.
 
 
 .. py:function:: random(n)

--- a/source/microbit/modmicrobit.cpp
+++ b/source/microbit/modmicrobit.cpp
@@ -40,7 +40,12 @@ STATIC mp_obj_t microbit_reset_(void) {
 MP_DEFINE_CONST_FUN_OBJ_0(microbit_reset_obj, microbit_reset_);
 
 STATIC mp_obj_t microbit_sleep(mp_obj_t ms_in) {
-    mp_int_t ms = mp_obj_get_int(ms_in);
+    mp_int_t ms;
+    if (mp_obj_is_integer(ms_in)) {
+        ms = mp_obj_get_int(ms_in);
+    } else {
+        ms = (mp_int_t)mp_obj_get_float(ms_in);
+    }
     if (ms > 0) {
         mp_hal_delay_ms(ms);
     }


### PR DESCRIPTION
Addresses issue #7.