### PR TITLE
Modify I2C address argument so that it's a 7-bit address.

### DIFF
--- a/docs/i2c.rst
+++ b/docs/i2c.rst
@@ -19,14 +19,14 @@ Functions
 
 .. py:function:: read(addr, n, repeat=False)
 
-    Read ``n`` bytes from the device with address ``addr``. If ``repeat`` is
-    ``True``, no stop bit will be sent.
+    Read ``n`` bytes from the device with 7-bit address ``addr``. If ``repeat``
+    is ``True``, no stop bit will be sent.
 
 
 .. py:function:: write(addr, buf, repeat=False)
 
-    Write bytes from ``buf`` to the device with address ``addr``. If ``repeat``
-    is ``True``, no stop bit will be sent.
+    Write bytes from ``buf`` to the device with 7-bit address ``addr``. If
+    ``repeat`` is ``True``, no stop bit will be sent.
 
 
 Connecting

--- a/source/microbit/microbiti2c.cpp
+++ b/source/microbit/microbiti2c.cpp
@@ -51,7 +51,7 @@ STATIC mp_obj_t microbit_i2c_read(mp_uint_t n_args, const mp_obj_t *pos_args, mp
     // do the I2C read
     vstr_t vstr;
     vstr_init_len(&vstr, args[1].u_int);
-    int err = self->i2c->read(args[0].u_int, vstr.buf, vstr.len, args[2].u_bool);
+    int err = self->i2c->read(args[0].u_int << 1, vstr.buf, vstr.len, args[2].u_bool);
     if (err != MICROBIT_OK) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError, "I2C read failed with error code %d", err));
     }
@@ -75,7 +75,7 @@ STATIC mp_obj_t microbit_i2c_write(mp_uint_t n_args, const mp_obj_t *pos_args, m
     // do the I2C write
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[1].u_obj, &bufinfo, MP_BUFFER_READ);
-    int err = self->i2c->write(args[0].u_int, (char*)bufinfo.buf, bufinfo.len, args[2].u_bool);
+    int err = self->i2c->write(args[0].u_int << 1, (char*)bufinfo.buf, bufinfo.len, args[2].u_bool);
     if (err != MICROBIT_OK) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError, "I2C write failed with error code %d", err));
     }


### PR DESCRIPTION
Input address to i2c.read and i2c.write is now a proper 7-bit address.

Addresses (no pun intended!) issue #119.