### PR TITLE
Correct spelling mistakes discovered in docs and examples.

### DIFF
--- a/docs/compass.rst
+++ b/docs/compass.rst
@@ -28,7 +28,7 @@ Functions
     returns ``False`` otherwise.
 
 
-.. py:function:: clear_calibrarion()
+.. py:function:: clear_calibration()
 
     Undoes the calibration, making the compass uncalibrated again.
 

--- a/docs/pin.rst
+++ b/docs/pin.rst
@@ -110,7 +110,7 @@ to that.
 
 .. note::
     Those classes are not actually available for the user, you can't create
-    new instances of them. You can only use the instaces already provided,
+    new instances of them. You can only use the instances already provided,
     representing the physical pins on your board.
 
 .. py:class:: MicroBitDigitalPin

--- a/docs/uart.rst
+++ b/docs/uart.rst
@@ -34,7 +34,7 @@ Functions
         * 115200
 
     The ``bits`` defines the size of bytes being transmitted, and the board
-    only supports 8. The ``parity`` parameter defines how partity is checked,
+    only supports 8. The ``parity`` parameter defines how parity is checked,
     and it can be ``None``, ``microbit.uart.ODD`` or ``microbit.uart.EVEN``.
     The ``stop`` parameter tells the number of stop bits, and has to be 1 for
     this board.

--- a/examples/conway.py
+++ b/examples/conway.py
@@ -22,7 +22,7 @@ def conway_step():
     global arena1, arena2
     for i in range(5 * 5): # loop over pixels
         i = 8 + (i // 5) * 7 + i % 5
-        # count number of neigbours
+        # count number of neighbours
         num_neighbours = (arena1[i - 8] +
                 arena1[i - 7] +
                 arena1[i - 6] +
@@ -37,7 +37,7 @@ def conway_step():
         if self and not (2 <= num_neighbours <= 3):
             arena2[i] = 0 # not enough, or too many neighbours: cell dies
         elif not self and num_neighbours == 3:
-            arena2[i] = 1 # exactly 3 neigbours around an empty cell: cell is born
+            arena2[i] = 1 # exactly 3 neighbours around an empty cell: cell is born
         else:
             arena2[i] = self # stay as-is
     # swap the buffers (arena1 is now the new one to display)

--- a/examples/watch.py
+++ b/examples/watch.py
@@ -59,10 +59,10 @@ mode = 0
 modes = {0:"clock", 1:"set h", 2:"mx10", 3:"m"}
 
 
-def decode_time(miliseconds):
-    """Converts a time in miliseconds into a string with hours:minutes,"""
-    mins = int(miliseconds / (1000 * 60) % 60)
-    hrs = int(miliseconds / (1000 * 60 * 60) % 24)
+def decode_time(milliseconds):
+    """Converts a time in milliseconds into a string with hours:minutes,"""
+    mins = int(milliseconds / (1000 * 60) % 60)
+    hrs = int(milliseconds / (1000 * 60 * 60) % 24)
     return "{h:0>2}:{m:0>2}".format(h=hrs, m=mins)
 
 


### PR DESCRIPTION
These are "public" facing mistakes that should be corrected. Based upon fixes suggested in #123 