### PR TITLE
Clear display when animation is interrupted.

### DIFF
--- a/source/microbit/microbitdisplay.cpp
+++ b/source/microbit/microbitdisplay.cpp
@@ -142,8 +142,8 @@ STATIC void wait_for_event() {
     while (!wakeup_event) {
         // allow CTRL-C to stop the animation
         if (MP_STATE_VM(mp_pending_exception) != MP_OBJ_NULL) {
-            async_stop();
-            return;
+            async_mode = ASYNC_MODE_CLEAR;
+            break;
         }
         __WFI();
     }


### PR DESCRIPTION
Clears the display when scrolling is interrupted.
Otherwise, pressing ctrl C can leave part of a character on the display.