### PR TITLE
Tiny change to help_text to document paste mode

### DIFF
--- a/source/microbit/help.c
+++ b/source/microbit/help.c
@@ -51,6 +51,7 @@ STATIC const char *help_text =
 "Control commands:\n"
 "  CTRL-C        -- stop a running program\n"
 "  CTRL-D        -- on a blank line, do a soft reset of the micro:bit\n"
+"  CTRL-E        -- enter paste mode, turning off auto-indent\n"
 "\n"
 "Available modules: antigravity, array, collections, gc, love, math,\n"
 "micropython, music, struct, sys, this\n"


### PR DESCRIPTION
Paste mode is super useful once you go beyond a few lines and are making use of an editor on the side. However it's not so easy to discover how to enable it unless you know where to look in the micropython documentation. I think it deserves to be up front in the help.