### PR TITLE
Doc updates

### DIFF
--- a/docs/ble.rst
+++ b/docs/ble.rst
@@ -1,0 +1,9 @@
+Bluetooth
+*********
+
+While the BBC micro:bit has Bluetooth Low Energy (BLE) hardware it only has
+16k of RAM. The BLE stack alone takes up 12k RAM which means there's not enough
+room to (currently) run MicroPython.
+
+Future versions of the device may come with 32k RAM which would be sufficient.
+However, until such time it's highly unlikely MicroPython will support BLE.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,6 +47,7 @@ Projects related to MicroPython on the BBC micro:bit include:
     lessons/gestures
     lessons/direction
     lessons/network
+    lessons/next
 
 .. toctree::
    :maxdepth: 2
@@ -66,6 +67,7 @@ Projects related to MicroPython on the BBC micro:bit include:
    spi.rst
    random.rst
    neopixel.rst
+   ble.rst
 
 .. toctree::
    :maxdepth: 2

--- a/docs/lessons/next.rst
+++ b/docs/lessons/next.rst
@@ -1,0 +1,34 @@
+Next Steps
+----------
+
+These tutorials are only the first steps in using MicroPython with the
+BBC micro:bit. A musical analogy: you've got a basic understanding of
+a very simple instrument and confidently play "Three Blind Mice".
+
+This is an achievement to build upon.
+
+Ahead of you is an exciting journey to becoming a virtuoso coder.
+
+You will encounter frustration, failure and foolishness. When you do please
+remember that you're not alone. Python has a secret weapon: the most amazing
+community of programmers on the planet. Connect with this community and you
+will make friends, find mentors, support each other and share resources.
+
+The examples in the tutorials are simple to explain but may not be the simplest
+or most efficient implementations. We've left out lots of *really fun stuff* so
+we could concentrate on arming you with the basics. If you *really* want to
+know how to make MicroPython fly on the BBC micro:bit then read the API
+reference documentation. It contains information about *all* the capabilities
+available to you.
+
+Explore, experiment and be fearless trying things out ~ for these are the
+attributes of a virtuoso coder. To encourage you we have hidden a number of
+Easter eggs in MicroPython and the code editors (both TouchDevelop and Mu).
+They're fun rewards for looking "under the hood" and "poking with a stick".
+
+Such skill in Python is valuable: it's one of the world's most popular
+professional programming languages.
+
+Amaze us with your code! Make things that delight us! Most of all, have fun!
+
+Happy hacking!

--- a/docs/microbit.rst
+++ b/docs/microbit.rst
@@ -13,8 +13,8 @@ Functions
 
 .. py:function:: panic(n)
 
-    Enter a panic mode. Requires restart. Pass in an arbitrary integer to
-    indicate a status::
+    Enter a panic mode. Requires restart. Pass in an arbitrary integer <= 255
+    to indicate a status::
 
         microbit.panic(404)
 

--- a/source/microbit/help.c
+++ b/source/microbit/help.c
@@ -54,7 +54,7 @@ STATIC const char *help_text =
 "  CTRL-E        -- enter paste mode, turning off auto-indent\n"
 "\n"
 "Available modules: antigravity, array, collections, gc, love, math,\n"
-"micropython, music, struct, sys, this\n"
+"micropython, music, neopixel, random, struct, sys, this\n"
 "\n"
 "For more information about Python, visit: http://python.org/\n"
 "To find out about MicroPython, visit: http://micropython.org/\n"

--- a/source/microbit/modthis.cpp
+++ b/source/microbit/modthis.cpp
@@ -34,7 +34,7 @@ extern "C" {
 
 STATIC mp_obj_t this__init__(void) {
     STATIC const char *this_text =
-"The Zen of MicroPython, by Nicholas H.Tollervey\n"
+"The Zen of MicroPython, by Nicholas H. Tollervey\n"
 "\n"
 "Code,\n"
 "Hack it,\n"
@@ -57,7 +57,10 @@ STATIC mp_obj_t this_authors(void) {
     */
     STATIC const char *authors_text =
 "MicroPython on the micro:bit is brought to you by:\n"
-"Damien P. George, Matthew Else, Abbie Brooks and Nicholas H. Tollervey.\n";
+"Damien P. George, Mark Shannon, Radomir Dopieralski, Matthew Else,\n"
+"Carol Willing, Tom Viner, Alan Jackson, Nick Coghlan, Joseph Haig,\n"
+"Alex Chan, Andrea Grandi, Paul Egan, Piotr Kasprzyk, Andrew Mulholland,\n"
+"Matt Wheeler, Joe Glancy, Abbie Brooks and Nicholas H. Tollervey.\n";
     mp_printf(&mp_plat_print, "%s", authors_text);
     return mp_const_none;
 }


### PR DESCRIPTION
This branch introduces four changes:

* Add missing modules to the help text.
* Include an appropriate BLE place-holder in the docs.
* Add a "Next Steps" conclusion to the tutorials.
* Update the `this` module with a full list of the current contributors.