### PR TITLE
Put music async object pointers in root pointer structure.

### DIFF
--- a/inc/microbit/mpconfigport.h
+++ b/inc/microbit/mpconfigport.h
@@ -113,6 +113,7 @@ extern const struct _mp_obj_module_t random_module;
     const char *readline_hist[8]; \
     mp_obj_t keyboard_interrupt_obj; \
     void *async_data[2]; \
+    void *async_music_data; \
 
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>

--- a/source/microbit/mprun.c
+++ b/source/microbit/mprun.c
@@ -120,6 +120,7 @@ void mp_run(void) {
     mp_hal_stdout_tx_str("soft reboot\r\n");
 
     memset(&MP_STATE_PORT(async_data)[0], 0, sizeof(MP_STATE_PORT(async_data)));
+    MP_STATE_PORT(async_music_data) = NULL;
 
     mp_deinit();
 }


### PR DESCRIPTION
This makes sure that wait=False works correctly by keeping the notes around during their playing.

Addresses issue #218.