### PR TITLE
New, much more efficient ticker. Reduces overhead of display rendering by about 90%.

### DIFF
--- a/inc/lib/ticker.h
+++ b/inc/lib/ticker.h
@@ -1,0 +1,30 @@
+#ifndef __MICROPY_INCLUDED_LIB_TICKER_H__
+#define __MICROPY_INCLUDED_LIB_TICKER_H__
+
+/*************************************
+ * 62.5kHz (16µs cycle time) ticker.
+ ************************************/
+
+#include "nrf.h"
+
+void ticker_init(void);
+void ticker_start(void);
+void ticker_stop(void);
+
+typedef void (*callback_ptr)(void);
+typedef int32_t (*ticker_callback_ptr)(void);
+
+int clear_ticker_callback(uint32_t index);
+int set_ticker_callback(uint32_t index, ticker_callback_ptr func, int32_t initial_delay_us);
+
+int set_low_priority_callback(callback_ptr callback, int id);
+
+#define CYCLES_PER_MICROSECONDS 16
+
+#define MICROSECONDS_PER_TICK 16
+#define CYCLES_PER_TICK (CYCLES_PER_MICROSECONDS*MICROSECONDS_PER_TICK)
+// This must be an integer multiple of MICROSECONDS_PER_TICK
+#define MICROSECONDS_PER_MACRO_TICK 6000
+#define MILLISECONDS_PER_MACRO_TICK 6
+
+#endif // __MICROPY_INCLUDED_LIB_TICKER_H__

--- a/inc/lib/ticker.h
+++ b/inc/lib/ticker.h
@@ -7,12 +7,12 @@
 
 #include "nrf.h"
 
-void ticker_init(void);
-void ticker_start(void);
-void ticker_stop(void);
-
 typedef void (*callback_ptr)(void);
 typedef int32_t (*ticker_callback_ptr)(void);
+
+void ticker_init(callback_ptr slow_ticker_callback);
+void ticker_start(void);
+void ticker_stop(void);
 
 int clear_ticker_callback(uint32_t index);
 int set_ticker_callback(uint32_t index, ticker_callback_ptr func, int32_t initial_delay_us);

--- a/inc/microbit/microbitdisplay.h
+++ b/inc/microbit/microbitdisplay.h
@@ -8,17 +8,16 @@
 typedef struct _microbit_display_obj_t {
     mp_obj_base_t base;
     uint8_t image_buffer[5][5];
-    uint8_t row_brightness[MICROBIT_DISPLAY_COLUMN_COUNT];
     uint8_t previous_brightness;
     /* Current row for strobing */
     uint8_t strobe_row;
     /* boolean histogram of brightness in buffer */
     uint16_t brightnesses;
-    uint16_t strobe_mask;
-    
+    uint16_t pins_for_brightness[MAX_BRIGHTNESS+1];
+
     void advanceRow();
-    void renderRow();
     inline void setPinsForRow(uint8_t brightness);
+
     
 } microbit_display_obj_t;
 

--- a/inc/microbit/mpconfigport.h
+++ b/inc/microbit/mpconfigport.h
@@ -126,3 +126,7 @@ extern const struct _mp_obj_module_t random_module;
 #ifndef M_PI
 #define M_PI (3.141592653589793)
 #endif
+
+// The ticker callback function
+extern void microbit_ticker(void);
+

--- a/source/lib/ticker.c
+++ b/source/lib/ticker.c
@@ -1,0 +1,166 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Mark Shannon
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "stddef.h"
+#include "lib/ticker.h"
+
+#define FastTicker NRF_TIMER0
+#define FastTicker_IRQn TIMER0_IRQn
+#define FastTicker_IRQHandler TIMER0_IRQHandler
+
+#define SlowTicker_IRQn SWI3_IRQn
+#define SlowTicker_IRQHandler SWI3_IRQHandler
+
+#define LowPriority_IRQn SWI4_IRQn
+#define LowPriority_IRQHandler SWI4_IRQHandler
+
+void ticker_init(void) {
+    NRF_TIMER_Type *ticker = FastTicker;
+    ticker->POWER = 1;
+    __NOP();
+    ticker_stop();
+    ticker->TASKS_CLEAR = 1;
+    ticker->CC[3] = MICROSECONDS_PER_MACRO_TICK;
+    ticker->MODE = TIMER_MODE_MODE_Timer;
+    ticker->BITMODE = TIMER_BITMODE_BITMODE_24Bit << TIMER_BITMODE_BITMODE_Pos;
+    ticker->PRESCALER = 4; // 1 tick == 1 microsecond
+    ticker->INTENSET = TIMER_INTENSET_COMPARE3_Msk;
+    ticker->SHORTS = 0;
+    NVIC_SetPriority(FastTicker_IRQn, 1);
+    NVIC_SetPriority(SlowTicker_IRQn, 2);
+    NVIC_SetPriority(LowPriority_IRQn, 3);
+    NVIC_EnableIRQ(SlowTicker_IRQn);
+    NVIC_EnableIRQ(LowPriority_IRQn);
+}
+
+/* Start and stop timer 0 including workarounds for Anomaly 73 for Timer
+* http://www.nordicsemi.com/eng/content/download/29490/494569/file/nRF51822-PAN%20v3.0.pdf
+*/
+void ticker_start(void) {
+    NVIC_EnableIRQ(FastTicker_IRQn);
+    *(uint32_t *)0x40008C0C = 1; //for Timer 0
+    FastTicker->TASKS_START = 1;
+}
+
+void ticker_stop(void) {
+    NVIC_DisableIRQ(FastTicker_IRQn);
+    FastTicker->TASKS_STOP = 1;
+    *(uint32_t *)0x40008C0C = 0; //for Timer 0
+}
+
+int32_t noop(void) {
+    return -1;
+}
+
+extern uint32_t ticks;
+
+static ticker_callback_ptr callbacks[3] = { noop, noop, noop };
+
+void FastTicker_IRQHandler(void) {
+    NRF_TIMER_Type *ticker = FastTicker;
+    ticker_callback_ptr *call = callbacks;
+    if (ticker->EVENTS_COMPARE[0]) {
+        ticker->EVENTS_COMPARE[0] = 0;
+        ticker->CC[0] += call[0]()*MICROSECONDS_PER_TICK;
+    }
+    if (ticker->EVENTS_COMPARE[1]) {
+        ticker->EVENTS_COMPARE[1] = 0;
+        ticker->CC[1] += call[1]()*MICROSECONDS_PER_TICK;
+    }
+    if (ticker->EVENTS_COMPARE[2]) {
+        ticker->EVENTS_COMPARE[2] = 0;
+        ticker->CC[2] += call[2]()*MICROSECONDS_PER_TICK;
+    }
+    if (ticker->EVENTS_COMPARE[3]) {
+        ticker->EVENTS_COMPARE[3] = 0;
+        ticker->CC[3] += MICROSECONDS_PER_MACRO_TICK;
+        ticks += MILLISECONDS_PER_MACRO_TICK;
+        NVIC_SetPendingIRQ(SlowTicker_IRQn);
+    }
+}
+
+
+static const uint32_t masks[3] = {
+    TIMER_INTENCLR_COMPARE0_Msk,
+    TIMER_INTENCLR_COMPARE1_Msk,
+    TIMER_INTENCLR_COMPARE2_Msk,
+};
+
+int set_ticker_callback(uint32_t index, ticker_callback_ptr func, int32_t initial_delay_us) {
+    if (index > 3)
+        return -1;
+    NRF_TIMER_Type *ticker = FastTicker;
+    callbacks[index] = noop;
+    ticker->INTENCLR = masks[index];
+    ticker->TASKS_CAPTURE[index] = 1;
+    uint32_t t = FastTicker->CC[index];
+    // Need to make sure that set tick is aligned to lastest tick
+    // Use CC[3] as a reference, as that is always up-to-date.
+    int32_t cc3 = FastTicker->CC[3];
+    int32_t delta = t+initial_delay_us-cc3;
+    delta = (delta/MICROSECONDS_PER_TICK+1)*MICROSECONDS_PER_TICK;
+    callbacks[index] = func;
+    ticker->INTENSET = masks[index];
+    FastTicker->CC[index] = cc3 + delta;
+    return 0;
+}
+
+int clear_ticker_callback(uint32_t index) {
+    if (index > 3)
+        return -1;
+    FastTicker->INTENCLR = masks[index];
+    callbacks[index] = noop;
+    return 0;
+}
+
+extern void ticker(void);
+
+void SlowTicker_IRQHandler(void)
+{
+    ticker();
+}
+
+#define LOW_PRIORITY_CALLBACK_LIMIT 4
+callback_ptr low_priority_callbacks[LOW_PRIORITY_CALLBACK_LIMIT] = { NULL, NULL, NULL, NULL };
+
+void LowPriority_IRQHandler(void)
+{
+    for (int id = 0; id < LOW_PRIORITY_CALLBACK_LIMIT; id++) {
+        callback_ptr callback = low_priority_callbacks[id];
+        if (callback != NULL) {
+            low_priority_callbacks[id] = NULL;
+            callback();
+        }
+    }
+}
+
+int set_low_priority_callback(callback_ptr callback, int id) {
+    if (low_priority_callbacks[id] != NULL)
+        return -1;
+    low_priority_callbacks[id] = callback;
+    NVIC_SetPendingIRQ(LowPriority_IRQn);
+    return 0;
+}

--- a/source/lib/ticker.c
+++ b/source/lib/ticker.c
@@ -37,7 +37,11 @@
 #define LowPriority_IRQn SWI4_IRQn
 #define LowPriority_IRQHandler SWI4_IRQHandler
 
-void ticker_init(void) {
+// Ticker callback function called every MACRO_TICK
+static callback_ptr slow_ticker;
+
+void ticker_init(callback_ptr slow_ticker_callback) {
+    slow_ticker = slow_ticker_callback;
     NRF_TIMER_Type *ticker = FastTicker;
     ticker->POWER = 1;
     __NOP();
@@ -136,11 +140,9 @@ int clear_ticker_callback(uint32_t index) {
     return 0;
 }
 
-extern void ticker(void);
-
 void SlowTicker_IRQHandler(void)
 {
-    ticker();
+    slow_ticker();
 }
 
 #define LOW_PRIORITY_CALLBACK_LIMIT 4

--- a/source/microbit/main.cpp
+++ b/source/microbit/main.cpp
@@ -4,6 +4,8 @@
 #include "microbitmusic.h"
 
 extern "C" {
+#include "lib/ticker.h"
+
     void mp_run(void);
     
     void microbit_button_init(void);
@@ -37,10 +39,9 @@ void app_main() {
     }
 }
 
-void ticker(void) {
+extern "C" {
 
-    // increment our real-time counter.
-    ticks += FIBER_TICK_PERIOD_MS;
+void ticker(void) {
 
     /** Update compass if it is calibrating, but not if it is still
      *  updating as compass.idleTick() is not reentrant.
@@ -66,8 +67,6 @@ void ticker(void) {
     microbit_music_tick();
 }
 
-extern "C" {
-
 // We need to override this function so that the linker does not pull in
 // unnecessary code and static RAM usage for unused system exit functionality.
 // There can be large static data structures to store the exit functions.
@@ -77,8 +76,10 @@ void __register_exitproc() {
 void microbit_init(void) {
     microbit_display_init();
 
-    // Hijack the DAL system ticker.
-    uBit.systemTicker.attach_us(ticker, MICROBIT_DEFAULT_TICK_PERIOD * 1000);
+    // Start the ticker.
+    uBit.systemTicker.detach();
+    ticker_init();
+    ticker_start();
 }
 
 }

--- a/source/microbit/main.cpp
+++ b/source/microbit/main.cpp
@@ -41,7 +41,7 @@ void app_main() {
 
 extern "C" {
 
-void ticker(void) {
+void microbit_ticker(void) {
 
     /** Update compass if it is calibrating, but not if it is still
      *  updating as compass.idleTick() is not reentrant.
@@ -78,7 +78,7 @@ void microbit_init(void) {
 
     // Start the ticker.
     uBit.systemTicker.detach();
-    ticker_init();
+    ticker_init(microbit_ticker);
     ticker_start();
 }
 

--- a/source/microbit/microbitcompass.cpp
+++ b/source/microbit/microbitcompass.cpp
@@ -26,10 +26,10 @@
 
 #include "MicroBit.h"
 
+extern "C" {
+
 // we need to access this for the compass calibration
 extern void ticker(void);
-
-extern "C" {
 
 #include "py/runtime.h"
 #include "modmicrobit.h"

--- a/source/microbit/microbitcompass.cpp
+++ b/source/microbit/microbitcompass.cpp
@@ -28,9 +28,7 @@
 
 extern "C" {
 
-// we need to access this for the compass calibration
-extern void ticker(void);
-
+#include "lib/ticker.h"
 #include "py/runtime.h"
 #include "modmicrobit.h"
 
@@ -50,11 +48,13 @@ mp_obj_t microbit_compass_calibrate(mp_obj_t self_in) {
     // can use the display to collect samples for the calibration.
     // It will do the calibration and then return here.
     microbit_compass_obj_t *self = (microbit_compass_obj_t*)self_in;
+    ticker_stop();
     uBit.systemTicker.attach_us(&uBit, &MicroBit::systemTick, MICROBIT_DEFAULT_TICK_PERIOD * 1000);
     uBit.display.enable();
-    self->compass->calibrateAsync();
+    self->compass->calibrate();
     uBit.display.disable();
-    uBit.systemTicker.attach_us(ticker, MICROBIT_DEFAULT_TICK_PERIOD * 1000);
+    uBit.systemTicker.detach();
+    ticker_start();
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_calibrate_obj, microbit_compass_calibrate);

--- a/source/microbit/microbitdisplay.cpp
+++ b/source/microbit/microbitdisplay.cpp
@@ -35,6 +35,7 @@ extern "C" {
 #include "microbitimage.h"
 #include "microbitdisplay.h"
 #include "lib/iters.h"
+#include "lib/ticker.h"
 
 void microbit_display_show(microbit_display_obj_t *display, microbit_image_obj_t *image) {
     mp_int_t w = min(image->width(), 5);
@@ -169,96 +170,79 @@ static const DisplayPoint display_map[MICROBIT_DISPLAY_COLUMN_COUNT][MICROBIT_DI
     {{1,2}, {NO_CONN,NO_CONN}, {3,2}}
 };
 
+#define MIN_COLUMN_PIN 4
+#define COLUMN_PINS_MASK 0x1ff0
+#define MIN_ROW_PIN 13
+#define MAX_ROW_PIN 15
+
 inline void microbit_display_obj_t::setPinsForRow(uint8_t brightness) {
-    int column_strobe = 0;
-
-    // Calculate the bitpattern to write.
-    for (int i = 0; i < MICROBIT_DISPLAY_COLUMN_COUNT; i++) {
-        if (row_brightness[i] >= brightness) {
-            column_strobe |= (1 << i);
-        }
+    if (brightness == 0) {
+        nrf_gpio_pins_clear(COLUMN_PINS_MASK & ~this->pins_for_brightness[brightness]);
+    } else {
+        nrf_gpio_pins_set(this->pins_for_brightness[brightness]);
     }
-
-    // Wwrite the new bit pattern.
-    // Set port 0 4-7 and retain lower 4 bits.
-    nrf_gpio_port_write(NRF_GPIO_PORT_SELECT_PORT0, (~column_strobe<<4 & 0xF0) | (nrf_gpio_port_read(NRF_GPIO_PORT_SELECT_PORT0) & 0x0F));
-
-    // Set port 1 8-12 for the current row.
-    nrf_gpio_port_write(NRF_GPIO_PORT_SELECT_PORT1, strobe_mask | (~column_strobe>>4 & 0x1F));
 }
 
 void microbit_display_obj_t::advanceRow() {
     // First, clear the old row.
-
+    nrf_gpio_pins_set(COLUMN_PINS_MASK);
     // Clear the old bit pattern for this row.
-    // Clear port 0 4-7 and retain lower 4 bits.
-    nrf_gpio_port_write(NRF_GPIO_PORT_SELECT_PORT0, 0xF0 | (nrf_gpio_port_read(NRF_GPIO_PORT_SELECT_PORT0) & 0x0F));
-    // Clear port 1 8-12 for the current row.
-    nrf_gpio_port_write(NRF_GPIO_PORT_SELECT_PORT1, strobe_mask | 0x1F);
+    nrf_gpio_pin_clear(strobe_row+MIN_ROW_PIN);
 
     // Move on to the next row.
-    strobe_mask <<= 1;
     strobe_row++;
 
     // Reset the row counts and bit mask when we have hit the max.
     if (strobe_row == MICROBIT_DISPLAY_ROW_COUNT) {
         strobe_row = 0;
-        strobe_mask = 0x20;
     }
 
+    // Set pin for this row.
     // Prepare row for rendering.
+    for (int i = 0; i <= MAX_BRIGHTNESS; i++) {
+        pins_for_brightness[i] = 0;
+    }
     for (int i = 0; i < MICROBIT_DISPLAY_COLUMN_COUNT; i++) {
         int x = display_map[i][strobe_row].x;
         int y = display_map[i][strobe_row].y;
-        row_brightness[i] = microbit_display_obj.image_buffer[x][y];
+        uint8_t brightness = microbit_display_obj.image_buffer[x][y];
+        pins_for_brightness[brightness] |= (1<<(i+MIN_COLUMN_PIN));
     }
-    // Turn on any pixels that are at max.
-    setPinsForRow(MAX_BRIGHTNESS);
+    //Set pin for row
+    nrf_gpio_pin_set(strobe_row+MIN_ROW_PIN);
+    // Turn on any pixels that are at max
+    nrf_gpio_pins_clear(pins_for_brightness[MAX_BRIGHTNESS]);
 }
 
 static const uint16_t render_timings[] =
-// The timer precision is only about 32us, so these timing will be rounded.
-// The scale is exponential, each step is approx x1.9 greater than the previous.
-{   0, // Brightness, Duration (approx)
-    35,   //    1,     35
-    32,   //    2,     67
-    61,   //    3,     128
-    115,  //    4,     243
-    219,  //    5,     462
-    417,  //    6,     879
-    791,  //    7,     1670
-    1500, //    8,     3170
-//  Always on   9,    ~6000
+// The scale is (approximately) exponential,
+// each step is approx x1.9 greater than the previous.
+{   0, // Bright, Ticks Duration, Relative power
+    2,   //   1,   2,     32µs,     inf
+    2,   //   2,   4,     64µs,     200%
+    4,   //   3,   8,     128µs,    200%
+    7,   //   4,   15,    240µs,    187%
+    13,  //   5,   28,    448µs,    187%
+    25,  //   6,   53,    848µs,    189%
+    49,  //   7,   102,   1632µs,   192%
+    97,  //   8,   199,   3184µs,   195%
+// Always on  9,   375,   6000µs,   188%
 };
 
+#define DISPLAY_TICKER_SLOT 1
 
-// Egregious hack to work around paranoia in the DAL API.
-struct FakeMicroBitDisplay : public MicroBitComponent
-{
-    uint8_t width;
-    uint8_t height;
-    uint8_t brightness;
-    uint8_t strobeRow;
-    uint8_t strobeBitMsk;
-    uint8_t rotation;
-    uint8_t mode;
-    uint8_t greyscaleBitMsk;
-    uint8_t timingCount;
-    uint8_t errorTimeout;
-    Timeout renderTimer;
-};
-
-Timeout *renderTimer = &((FakeMicroBitDisplay*)(&(uBit.display)))->renderTimer;
-
-void microbit_display_obj_t::renderRow() {
-    mp_uint_t brightness = previous_brightness+1;
-    setPinsForRow(brightness);
+static int32_t callback(void) {
+    microbit_display_obj_t *display = &microbit_display_obj;
+    mp_uint_t brightness = display->previous_brightness;
+    display->setPinsForRow(brightness);
+    brightness += 1;
     if (brightness == MAX_BRIGHTNESS) {
-        return;
+        clear_ticker_callback(DISPLAY_TICKER_SLOT);
+        return -1;
     }
-    previous_brightness = brightness;
-    // Attach this function to the timer.
-    renderTimer->attach_us(this, &microbit_display_obj_t::renderRow, render_timings[brightness]);
+    display->previous_brightness = brightness;
+    // Return interval (in 16µs ticks) until next callback
+    return render_timings[brightness];
 }
 
 
@@ -331,7 +315,7 @@ void microbit_display_tick(void) {
     microbit_display_update();
     microbit_display_obj.previous_brightness = 0;
     if (microbit_display_obj.brightnesses & GREYSCALE_MASK) {
-        microbit_display_obj.renderRow();
+        set_ticker_callback(DISPLAY_TICKER_SLOT, callback, 1800);
     }
 }
 
@@ -460,11 +444,10 @@ STATIC const mp_obj_type_t microbit_display_type = {
 microbit_display_obj_t microbit_display_obj = {
     {&microbit_display_type},
     { 0 },
-    .row_brightness = { 0 },
     .previous_brightness = 0,
     .strobe_row = 0,
     .brightnesses = 0,
-    .strobe_mask = 0x20
+    .pins_for_brightness = { 0 },
 };
 
 void microbit_display_init(void) {


### PR DESCRIPTION
This is the first PR in a series aimed at bringing synthesised sound capabilities to the micro:bit.
Before we can handle sampled sound, we need an efficient and accurate timer.
(The hardware offers a range of quality timers, it is the software that is the problem).

The current timer used for rendering the display and doing the general updates is inefficient and jittery.
For example, on master, 
```python
display.show(Image("11111:"*5))
music.play(...)
```
will cause visible flicker as the tune plays.
"Greyscale" rendering can also interfere with the UART operation making `pyboard` unreliable.

With the new timer, there is no visible flicker regardless of the load, and the UART seems to operate correctly even with a "greyscale" image showing.

As well as being much more efficient, adding callbacks to the new timer never disables interrupts. This ensures that interrupts arrive exactly on time, which is important for sampled sound.

Some of the reduced overhead is from improvements to display rendering, but the vast majority is from the new timer.

## Performance Measurements

Unloaded throughput (in arbitrary units of work): 11974 (estimated 99.95% CPU available).
Estimated 100% throughput: 12034

Timer overhead is tested under two conditions.

1. The display cleared. 
2. Displaying the image:
    `Image("01234:56789:01234:56789:01234")`

### Throughput

Setup | Master | New Timer
------|--------|----------
Clear | 10959  | 11864
Image | 8669   | 11691

### Timer Overhead

Setup | Master | New Timer
------|--------|----------
Clear | 8.9%   | 1.4%
Image | 28.0%   | 2.9%

### Test program
```python
from microbit import *

if 0:   
    display.show(Image("01234:56789:01234:56789:01234"))

def use_time():
    i = 3
    while i:
        i -= 1
        
t = running_time()
work_done = 0

while running_time() - t < 5000:
    use_time()
    work_done += 1
    
print (work_done)
```




