### PR TITLE
Avoid the word "scope"

### DIFF
--- a/docs/tutorials/movement.rst
+++ b/docs/tutorials/movement.rst
@@ -30,7 +30,7 @@ If you hold the device flat it should display ``-``; however, rotate it left or
 right and it'll show ``L`` and ``R`` respectively.
 
 We want the device to constantly react to change, so we use an
-infinite ``while`` loop. The first thing to happen *within the scope of the
+infinite ``while`` loop. The first thing to happen *within the body of the
 loop* is a measurement along the X axis which is called ``reading``. Because
 the accelerometer is *so* sensitive I've made level +/-20 in range. It's why
 the ``if`` and ``elif`` conditionals check for ``> 20`` and ``< -20``. The

--- a/docs/tutorials/music.rst
+++ b/docs/tutorials/music.rst
@@ -134,4 +134,4 @@ collection, do some activity with it". Specifically in the example above, it's
 saying, "for each frequency in the specified range of frequencies, play the
 pitch of that frequency for 6 milliseconds". Notice how the thing to do for
 each item in a for loop is indented (as discussed earlier) so Python knows
-exactly which code to run for to handle the individual items.
+exactly which code to run to handle the individual items.

--- a/docs/tutorials/music.rst
+++ b/docs/tutorials/music.rst
@@ -134,4 +134,4 @@ collection, do some activity with it". Specifically in the example above, it's
 saying, "for each frequency in the specified range of frequencies, play the
 pitch of that frequency for 6 milliseconds". Notice how the thing to do for
 each item in a for loop is indented (as discussed earlier) so Python knows
-the *scope* of the code for handling individual items.
+exactly which code to run for to handle the individual items.


### PR DESCRIPTION
"Scope" has a specific meaning in Python (in the sense of "variable
scope") so it's best to avoid it when discussing other concepts.