### PR TITLE
Correct typo in (image * scalar) example

### DIFF
--- a/docs/image.rst
+++ b/docs/image.rst
@@ -174,6 +174,6 @@ each pixel.
 
 .. code::
 
-    image + n
+    image * n
 
 Create a new image by multiplying the brightness of each pixel by ``n``.


### PR DESCRIPTION
e.g. `Image.HEART + 1` throws a `TypeError` exception