### PR TITLE
Fix missing comma(s) in list of 8 ball responses

### DIFF
--- a/docs/tutorials/gestures.rst
+++ b/docs/tutorials/gestures.rst
@@ -63,8 +63,8 @@ easy to turn into a program::
         "Don't count on it"
         "My reply is no",
         "My sources say no",
-        "Outlook not so good"
-        "Very doubtful"
+        "Outlook not so good",
+        "Very doubtful",
     ]
 
     while True:

--- a/examples/magic8.py
+++ b/examples/magic8.py
@@ -25,8 +25,8 @@ answers = [
     "Don't count on it"
     "My reply is no",
     "My sources say no",
-    "Outlook not so good"
-    "Very doubtful"
+    "Outlook not so good",
+    "Very doubtful",
 ]
 
 while True:


### PR DESCRIPTION
The penultimate item in the 8-ball program is missing a trailing comma. I'm assuming this is an omission, and not an intentional big for the learners to fix.

I also took the liberty of adding a comma after the final item. If this is a bad feature/practise to show the learners please let me know and I'll amend this PR.