### PR TITLE
Added instructions for installing prerequisites needed for windows.

### DIFF
--- a/docs/devguide/installation.rst
+++ b/docs/devguide/installation.rst
@@ -38,6 +38,18 @@ Installation Scenarios
 Windows
 ~~~~~~~
 
+When installing `Yotta
+<http://yottadocs.mbed.com/>`_, make sure you have these components ticked to install.
+
+- python
+- gcc
+- cMake
+- ninja
+- Yotta
+- git-scm
+- mbed serial driver
+
+
 
 .. _microbit-osx:
 


### PR DESCRIPTION
This commit added into the documentation how to install Yotta on windows and what boxes need to be cheeked when installing.

Signed-off-by: Vincent Lee <vlee489@users.noreply.github.com>