### PR TITLE
Add microbit_obj_get_pin_name function to reduce need for MicroBit.h.

### DIFF
--- a/inc/microbit/microbitpin.h
+++ b/inc/microbit/microbitpin.h
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Damien P. George
+ * Copyright (c) 2016 Damien P. George
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,22 +23,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef __MICROPY_INCLUDED_MICROBIT_MICROBITOBJ_H__
-#define __MICROPY_INCLUDED_MICROBIT_MICROBITOBJ_H__
+#ifndef __MICROPY_INCLUDED_MICROBIT_MICROBITPIN_H__
+#define __MICROPY_INCLUDED_MICROBIT_MICROBITPIN_H__
 
-extern "C" {
+#ifndef MICROBIT_PIN_P0
 
-#include "py/obj.h"
+#define MICROBIT_PIN_P0     (P0_3)
+#define MICROBIT_PIN_P1     (P0_2)
+#define MICROBIT_PIN_P13    (P0_23)
+#define MICROBIT_PIN_P14    (P0_22)
+#define MICROBIT_PIN_P15    (P0_21)
 
-class MicroBitPin *microbit_obj_get_pin(mp_obj_t o);
-PinName microbit_obj_get_pin_name(mp_obj_t o);
+#endif
 
-extern volatile bool compass_up_to_date;
-extern volatile bool compass_updating;
-
-extern volatile bool accelerometer_up_to_date;
-extern volatile bool accelerometer_updating;
-
-}
-
-#endif // __MICROPY_INCLUDED_MICROBIT_MICROBITOBJ_H__
+#endif // __MICROPY_INCLUDED_MICROBIT_MICROBITPIN_H__

--- a/source/microbit/microbitpin.cpp
+++ b/source/microbit/microbitpin.cpp
@@ -214,4 +214,8 @@ MicroBitPin *microbit_obj_get_pin(mp_obj_t o) {
     }
 }
 
+PinName microbit_obj_get_pin_name(mp_obj_t o) {
+    return microbit_obj_get_pin(o)->name;
+}
+
 }

--- a/source/microbit/microbitspi.cpp
+++ b/source/microbit/microbitspi.cpp
@@ -24,13 +24,12 @@
  * THE SOFTWARE.
  */
 
-#include "spi_api.h"
-#include "MicroBit.h"
-
 extern "C" {
 
+#include "spi_api.h"
 #include "py/runtime.h"
 #include "modmicrobit.h"
+#include "microbitpin.h"
 #include "microbitobj.h"
 
 typedef struct _microbit_spi_obj_t {
@@ -61,13 +60,13 @@ STATIC mp_obj_t microbit_spi_init(mp_uint_t n_args, const mp_obj_t *pos_args, mp
     PinName p_mosi = MICROBIT_PIN_P15;
     PinName p_miso = MICROBIT_PIN_P14;
     if (args.sclk.u_obj != mp_const_none) {
-        p_sclk = microbit_obj_get_pin(args.sclk.u_obj)->name;
+        p_sclk = microbit_obj_get_pin_name(args.sclk.u_obj);
     }
     if (args.mosi.u_obj != mp_const_none) {
-        p_mosi = microbit_obj_get_pin(args.mosi.u_obj)->name;
+        p_mosi = microbit_obj_get_pin_name(args.mosi.u_obj);
     }
     if (args.miso.u_obj != mp_const_none) {
-        p_miso = microbit_obj_get_pin(args.miso.u_obj)->name;
+        p_miso = microbit_obj_get_pin_name(args.miso.u_obj);
     }
 
     // initialise the SPI

--- a/source/microbit/microbituart.cpp
+++ b/source/microbit/microbituart.cpp
@@ -24,16 +24,15 @@
  * THE SOFTWARE.
  */
 
-#include <errno.h>
-
-#include "MicroBit.h"
-
 extern "C" {
 
+#include <errno.h>
+#include "serial_api.h"
 #include "py/runtime.h"
 #include "py/stream.h"
 #include "py/mphal.h"
 #include "modmicrobit.h"
+#include "microbitpin.h"
 #include "microbitobj.h"
 
 // There is only one UART peripheral and it's already used by stdio (and
@@ -71,8 +70,8 @@ STATIC mp_obj_t microbit_uart_init(mp_uint_t n_args, const mp_obj_t *pos_args, m
     if (args[4].u_obj != mp_const_none) {
         mp_obj_t *pins;
         mp_obj_get_array_fixed_n(args[4].u_obj, 2, &pins);
-        p_tx = microbit_obj_get_pin(pins[0])->name;
-        p_rx = microbit_obj_get_pin(pins[1])->name;
+        p_tx = microbit_obj_get_pin_name(pins[0]);
+        p_rx = microbit_obj_get_pin_name(pins[1]);
     }
 
     // initialise the uart

--- a/source/microbit/modneopixel.cpp
+++ b/source/microbit/modneopixel.cpp
@@ -24,11 +24,10 @@
  * THE SOFTWARE.
  */
 
-#include <stdio.h>
-#include "MicroBit.h"
-
 extern "C" {
 
+#include <stdio.h>
+#include "gpio_api.h"
 #include "py/runtime0.h"
 #include "py/runtime.h"
 #include "lib/neopixel.h"
@@ -45,7 +44,7 @@ STATIC mp_obj_t neopixel_make_new(const mp_obj_type_t *type_in, mp_uint_t n_args
     (void)type_in;
     mp_arg_check_num(n_args, n_kw, 2, 2, false);
 
-    PinName pin = microbit_obj_get_pin(args[0])->name;
+    PinName pin = microbit_obj_get_pin_name(args[0]);
     mp_int_t num_pixels = mp_obj_get_int(args[1]);
 
     if (num_pixels <= 0) {


### PR DESCRIPTION
Added microbit_obj_get_pin_name, which returns the PinName value (from mbed API), and reduces the need for MicroBit.h.  There are no functional changes.

@markshannon this should mean you can make modaudio a pure .c file.