### PR TITLE
Reduce dependency on DAL for the display and images.

### DIFF
--- a/inc/microbit/MicroBitCustomConfig.h
+++ b/inc/microbit/MicroBitCustomConfig.h
@@ -20,7 +20,4 @@
 #define MICROBIT_BLE_DEVICE_INFORMATION_SERVICE     0
 #define MICROBIT_BLE_PAIRING_MODE   0
 
-// Slow this down a bit as proportional spacing reduces length
-#define MICROBIT_DEFAULT_SCROLL_SPEED       150
-
 #endif

--- a/inc/microbit/microbitobj.h
+++ b/inc/microbit/microbitobj.h
@@ -29,6 +29,7 @@
 extern "C" {
 
 #include "py/obj.h"
+#include "PinNames.h"
 
 class MicroBitPin *microbit_obj_get_pin(mp_obj_t o);
 PinName microbit_obj_get_pin_name(mp_obj_t o);

--- a/source/microbit/main.cpp
+++ b/source/microbit/main.cpp
@@ -74,6 +74,7 @@ void __register_exitproc() {
 }
 
 void microbit_init(void) {
+    uBit.display.disable();
     microbit_display_init();
 
     // Start the ticker.

--- a/source/microbit/microbitconstimage.cpp
+++ b/source/microbit/microbitconstimage.cpp
@@ -24,7 +24,6 @@
  * THE SOFTWARE.
  */
 
-#include "MicroBit.h"
 #include "microbitobj.h"
 
 extern "C" {

--- a/source/microbit/microbitimage.cpp
+++ b/source/microbit/microbitimage.cpp
@@ -24,8 +24,9 @@
  * THE SOFTWARE.
  */
 
-#include "MicroBit.h"
+#include <string.h>
 #include "microbitobj.h"
+#include "MicroBitFont.h"
 
 extern "C" {
 
@@ -33,6 +34,9 @@ extern "C" {
 #include "modmicrobit.h"
 #include "microbitimage.h"
 #include "py/runtime0.h"
+
+#define min(a,b) (((a)<(b))?(a):(b))
+#define max(a,b) (((a)>(b))?(a):(b))
 
 const monochrome_5by5_t microbit_blank_image = {
     { &microbit_image_type },
@@ -523,15 +527,17 @@ STATIC const mp_map_elem_t microbit_image_locals_dict_table[] = {
 
 STATIC MP_DEFINE_CONST_DICT(microbit_image_locals_dict, microbit_image_locals_dict_table);
 
+#define THE_FONT MicroBitFont::defaultFont
+
+#define ASCII_START 32
+#define ASCII_END 126
 
 STATIC const unsigned char *get_font_data_from_char(char c) {
-    MicroBitFont font = uBit.display.getFont();
-    if (c < MICROBIT_FONT_ASCII_START || c > font.asciiEnd) {
+    if (c < ASCII_START || c > ASCII_END) {
         c = '?';
     }
-    /* The following logic belongs in MicroBitFont */
-    int offset = (c-MICROBIT_FONT_ASCII_START) * 5;
-    return font.characters + offset;
+    int offset = (c-ASCII_START) * 5;
+    return THE_FONT + offset;
 }
 
 STATIC mp_int_t get_pixel_from_font_data(const unsigned char *data, int x, int y) {


### PR DESCRIPTION
Removes all dependencies on the DAL from `microbitdisplay.cpp` and `microbitconstimage.cpp`.

A dependency remains in `microbitimage.cpp`, but this is only on `MicroBitFont.h` which does not drag in the rest of the DAL.