### PR TITLE
In mphalport.{h,cpp},  Use "unsigned int" instead of "uint".

### DIFF
--- a/inc/microbit/mphalport.h
+++ b/inc/microbit/mphalport.h
@@ -36,8 +36,8 @@ void mp_hal_set_interrupt_char(int c);
 int mp_hal_stdin_rx_any(void);
 
 // provide these since we don't assume VT100 support
-void mp_hal_move_cursor_back(uint pos);
-void mp_hal_erase_line_from_cursor(uint n_chars);
+void mp_hal_move_cursor_back(unsigned int pos);
+void mp_hal_erase_line_from_cursor(unsigned int n_chars);
 
 void mp_hal_display_string(const char*);
 

--- a/source/microbit/mphalport.cpp
+++ b/source/microbit/mphalport.cpp
@@ -103,9 +103,9 @@ void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len) {
     }
 }
 
-STATIC void mp_hal_print_many(const char chrs[8], uint total) {
+STATIC void mp_hal_print_many(const char chrs[8], unsigned int total) {
     while (total > 0) {
-        uint n = total;
+        unsigned int n = total;
         if (n > 8) {
             n = 8;
         }
@@ -114,11 +114,11 @@ STATIC void mp_hal_print_many(const char chrs[8], uint total) {
     }
 }
 
-void mp_hal_move_cursor_back(uint pos) {
+void mp_hal_move_cursor_back(unsigned int pos) {
     mp_hal_print_many("\b\b\b\b\b\b\b\b", pos);
 }
 
-void mp_hal_erase_line_from_cursor(uint n_chars) {
+void mp_hal_erase_line_from_cursor(unsigned int n_chars) {
     mp_hal_print_many("        ", n_chars);
     mp_hal_move_cursor_back(n_chars);
 }


### PR DESCRIPTION
A recent change meant that uint was no longer being defined in some cases, and the build is now broken (at least on my system).  This change removes the dependency on the uint definition.