### PR TITLE
Fixed needle direction

### DIFF
--- a/examples/compass.py
+++ b/examples/compass.py
@@ -17,5 +17,5 @@ compass.calibrate()
 # Try to keep the needle pointed in (roughly) the correct direction
 while True:
     sleep(100)
-    needle = ((15 - compass.heading()) // 30) % 12
+    needle = ((compass.heading() - 15) // 30) % 12
     display.show(Image.ALL_CLOCKS[needle])


### PR DESCRIPTION
I'm not sure if I'm right here so please correct me if I'm wrong:

compass.heading() returns a number from 0 - 360 where 0 is N. I'm assuming 90 is E, 180 is S etc...

Without the change, the needle points NWW for 90 rather than E: the needle spins counter-clockwise rather than clockwise as the heading increases from 0 to 360.

See https://create.withcode.uk/python/55
