### PR TITLE
Use display.show instead of display.animate

### DIFF
--- a/examples/analog_watch.py
+++ b/examples/analog_watch.py
@@ -30,7 +30,7 @@ def ticks():
             on = not on
 
 #Run a clock speeded up 60 times, so we can watch the animation.
-display.animate(ticks(), 1000)
+display.show(ticks(), 1000)
 
 
 


### PR DESCRIPTION
The analog_watch example was using the outdated display.animate, so no longer worked. Change to display.show so that it works again.