### PR TITLE
README updates from a newbie on Debian.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,16 @@ with an ARM compiler toolchain (eg arm-none-eabi-gcc and friends).
 
 Ubuntu users can install the needed packages using:
 ```
-sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
+sudo add-apt-repository -y ppa:team-gcc-arm-embedded
 sudo add-apt-repository -y ppa:pmiller-opensource/ppa
 sudo apt-get update
-sudo apt-get install cmake ninja-build gcc-arm-none-eabi srecord
+sudo apt-get install cmake ninja-build gcc-arm-none-eabi srecord libssl-dev
 pip3 install yotta
 ```
 
-Once all packages are installed, use yotta to build.
+Once all packages are installed, use yotta to build.  You will need an ARM
+mbed account to complete the first command, and will be prompted to create one
+as a part of the process.
 
 - Use target bbc-microbit-classic-gcc-nosd:
 

--- a/docs/devguide/installation.rst
+++ b/docs/devguide/installation.rst
@@ -22,6 +22,9 @@ You will need:
 Depending on your operating system, the installation instructions vary. Use
 the installation scenario that best suits your system.
 
+Yotta will require an ARM mbed account.  It will walk you through signing up
+if you are not registered.
+
 Installation Scenarios
 ----------------------
 
@@ -74,10 +77,10 @@ Debian and Ubuntu
 
 ::
 
-  sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
+  sudo add-apt-repository -y ppa:team-gcc-arm-embedded
   sudo add-apt-repository -y ppa:pmiller-opensource/ppa
   sudo apt-get update
-  sudo apt-get install cmake ninja-build gcc-arm-none-eabi srecord
+  sudo apt-get install cmake ninja-build gcc-arm-none-eabi srecord libssl-dev
   pip3 install yotta
 
 


### PR DESCRIPTION
* mjs-arm reports that we should use ppa:team-gcc-arm-embedded. #203 

* yotta requires cryptography requires OpenSSL headers. #230 

* Debian does not have apt-add-repository in the base install.

* Debian names != Ubuntu names.

* Running yotta target requires an ARM mbed account.

The Debian instructions are potentially confusing. The Debian reality is definitely confusing. Please wordsmith.