### PR TITLE
Eliminate a compiler warning

### DIFF
--- a/source/microbit/mprun.c
+++ b/source/microbit/mprun.c
@@ -125,7 +125,7 @@ void mp_run(void) {
         if (APPENDED_SCRIPT->header[0] == 'M' && APPENDED_SCRIPT->header[1] == 'P') {
             // run appended script
             do_strn(APPENDED_SCRIPT->str, APPENDED_SCRIPT->len);
-        } else if (main_module = microbit_file_open("main.py", 7, false, false)) {
+        } else if ((main_module = microbit_file_open("main.py", 7, false, false)) != NULL) {
             do_file(main_module);
         } else {
             // from microbit import *


### PR DESCRIPTION
There are 4 compiler warnings from code directly in this repository. I would like to eliminate them.

Eliminating the first in mprun.c was trivial, but the three in microbitspi.cpp are not so easy to fix. GCC's missing initializer warning seems to find the `{}` initializer for structs very untasty. It's probably something to do with the details of the C/C++ standards that I don't yet understand.

So, this pull request only fixes one warning.
