### PR TITLE
Display: Prohibit allocation in interrupts.

### DIFF
--- a/docs/display.rst
+++ b/docs/display.rst
@@ -47,6 +47,12 @@ Functions
     Note that the ``wait``, ``loop`` and ``clear`` arguments must be specified
     using their keyword.
 
+.. note::
+
+    If using a generator as the ``iterable``, then take care not to allocate any memory
+    in the generator as allocating memory in an interrupt is prohibited and will raise a
+    ``MemoryError``.
+
 .. py:function:: scroll(string, delay=150, \*, wait=True, loop=False, monospace=False)
 
     Similar to ``show``, but scrolls the ``string`` horizontally instead. The

--- a/examples/analog_watch.py
+++ b/examples/analog_watch.py
@@ -30,7 +30,6 @@ def ticks():
             on = not on
 
 #Run a clock speeded up 60 times, so we can watch the animation.
-display.show(ticks(), 1000)
-
-
-
+for tick in ticks():
+    display.show(tick)
+    sleep(1000)

--- a/inc/microbit/microbitimage.h
+++ b/inc/microbit/microbitimage.h
@@ -37,6 +37,8 @@ typedef struct _greyscale_t {
     uint8_t width;
     uint8_t byte_data[]; /* Static initializer for this will have to be C, not C++ */
     void clear();
+    void shiftLeftInplace(mp_int_t n);
+    void shiftRightInplace(mp_int_t n);
     
     /* Thiese are internal methods and it is up to the caller to validate the inputs */
     uint8_t getPixelValue(mp_int_t x, mp_int_t y);

--- a/source/microbit/microbitdisplay.cpp
+++ b/source/microbit/microbitdisplay.cpp
@@ -30,6 +30,7 @@
 
 extern "C" {
 #include "py/runtime.h"
+#include "py/gc.h"
 #include "modmicrobit.h"
 #include "microbitimage.h"
 #include "microbitdisplay.h"
@@ -130,7 +131,6 @@ static volatile bool wakeup_event = false;
 static mp_uint_t async_delay = 1000;
 static mp_uint_t async_tick = 0;
 static bool async_clear = false;
-static bool async_error = true;
 
 STATIC void async_stop(void) {
     async_iterator = NULL;
@@ -281,6 +281,30 @@ static int32_t callback(void) {
     return render_timings[brightness];
 }
 
+static void draw_object(mp_obj_t obj) {
+    microbit_display_obj_t *display = (microbit_display_obj_t*)MP_STATE_PORT(async_data)[0];
+    if (obj == MP_OBJ_STOP_ITERATION) {
+        if (async_clear) {
+            microbit_display_show(&microbit_display_obj, BLANK_IMAGE);
+            async_clear = false;
+        } else {
+            async_stop();
+        }
+    } else if (mp_obj_get_type(obj) == &microbit_image_type) {
+        microbit_display_show(display, (microbit_image_obj_t *)obj);
+    } else if (MP_OBJ_IS_STR(obj)) {
+        mp_uint_t len;
+        const char *str = mp_obj_str_get_data(obj, &len);
+        if (len == 1) {
+            microbit_display_show(display, microbit_image_for_char(str[0]));
+        } else {
+            async_stop();
+        }
+    } else {
+        MP_STATE_VM(mp_pending_exception) = mp_obj_new_exception_msg(&mp_type_TypeError, "not an image.");
+        async_stop();
+    }
+}
 
 static void microbit_display_update(void) {
     async_tick += MILLISECONDS_PER_MACRO_TICK;
@@ -295,44 +319,29 @@ static void microbit_display_update(void) {
                 async_stop();
                 break;
             }
-            microbit_display_obj_t *display = (microbit_display_obj_t*)MP_STATE_PORT(async_data)[0];
             /* WARNING: We are executing in an interrupt handler.
              * If an exception is raised here then we must hand it to the VM. */
             mp_obj_t obj;
             nlr_buf_t nlr;
+            gc_lock();
             if (nlr_push(&nlr) == 0) {
                 obj = mp_iternext_allow_raise(async_iterator);
                 nlr_pop();
+                gc_unlock();
             } else {
+                gc_unlock();
                 if (!mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(((mp_obj_base_t*)nlr.ret_val)->type),
                     MP_OBJ_FROM_PTR(&mp_type_StopIteration))) {
-                    // an exception other than StopIteration, so set it for the VM to raise later
+                    // An exception other than StopIteration, so set it for the VM to raise later
+                    // If memory error, write an appropriate message.
+                    if (mp_obj_get_type(nlr.ret_val) == &mp_type_MemoryError) {
+                        mp_printf(&mp_plat_print, "Allocation in interrupt handler");
+                    }
                     MP_STATE_VM(mp_pending_exception) = MP_OBJ_FROM_PTR(nlr.ret_val);
                 }
                 obj = MP_OBJ_STOP_ITERATION;
             }
-            if (obj == MP_OBJ_STOP_ITERATION) {
-                if (async_clear) {
-                    microbit_display_show(&microbit_display_obj, BLANK_IMAGE);
-                    async_clear = false;
-                } else {
-                    async_stop();
-                }
-            } else if (mp_obj_get_type(obj) == &microbit_image_type) {
-                microbit_display_show(display, (microbit_image_obj_t *)obj);
-            } else if (MP_OBJ_IS_STR(obj)) {
-                mp_uint_t len;
-                const char *str = mp_obj_str_get_data(obj, &len);
-                if (len == 1) {
-                    microbit_display_show(display, microbit_image_for_char(str[0]));
-                } else {
-                    async_error = true;
-                    async_stop();
-                }
-            } else {
-                async_error = true;
-                async_stop();
-            }
+            draw_object(obj);
             break;
         }
         case ASYNC_MODE_CLEAR:
@@ -367,13 +376,14 @@ void microbit_display_animate(microbit_display_obj_t *self, mp_obj_t iterable, m
     MP_STATE_PORT(async_data)[0] = NULL;
     MP_STATE_PORT(async_data)[1] = NULL;
     async_iterator = mp_getiter(iterable);
-    async_error = false;
     async_delay = delay;
     async_clear = clear;
     MP_STATE_PORT(async_data)[0] = self; // so it doesn't get GC'd
     MP_STATE_PORT(async_data)[1] = async_iterator;
     wakeup_event = false;
     async_mode = ASYNC_MODE_ANIMATION;
+    mp_obj_t obj = mp_iternext_allow_raise(async_iterator);
+    draw_object(obj);
     if (wait) {
         wait_for_event();
     }


### PR DESCRIPTION
This prevents non-deterministic and impossible-to-debug errors caused by asynchronous GC.

Unless we can make the GC fully re-entrant from interrupts, which is not feasible, then we must prohibit GC in interrupts. 
This PR does that. (https://github.com/bbcmicrobit/micropython/pull/314 does the same for audio)