### PR TITLE
Changes  panic example code to less than 255

### DIFF
--- a/docs/microbit.rst
+++ b/docs/microbit.rst
@@ -16,7 +16,7 @@ Functions
     Enter a panic mode. Requires restart. Pass in an arbitrary integer <= 255
     to indicate a status::
 
-        microbit.panic(404)
+        microbit.panic(255)
 
 
 .. py:function:: reset()


### PR DESCRIPTION
404 is more than the limit of 255 stated in the docs. This makes the previous example misleading.