### PR TITLE
Add missing comma to answer list

### DIFF
--- a/examples/magic8.py
+++ b/examples/magic8.py
@@ -22,7 +22,7 @@ answers = [
     "Better not tell you now",
     "Cannot predict now",
     "Concentrate and ask again",
-    "Don't count on it"
+    "Don't count on it",
     "My reply is no",
     "My sources say no",
     "Outlook not so good",


### PR DESCRIPTION
Does not cause an error, but does cause 2 elements to be unnecessarily concatenated.  Only spotted this as my first random line was effected.