### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Tab completion works and is very useful!
 
 Read our documentation here:
 
-http://microbit-micropython.readthedocs.org/en/latest/
+https://microbit-micropython.readthedocs.io/en/latest/
 
 You can also use the tools/pyboard.py script to run Python scripts directly
 from your PC, eg:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ mailing list (https://mail.python.org/mailman/listinfo/microbit).
 Projects related to MicroPython on the BBC micro:bit include:
 
 * `Mu <https://github.com/ntoll/mu>`_ - a simple code editor for kids, teachers and beginner programmers. Probably the easiest way for people to program MicroPython on the BBC micro:bit.
-* `uFlash <http://uflash.readthedocs.org/en/latest/>`_ - a command line tool for flashing raw Python scripts onto a BBC micro:bit.
+* `uFlash <https://uflash.readthedocs.io/en/latest/>`_ - a command line tool for flashing raw Python scripts onto a BBC micro:bit.
 
 .. toctree::
     :maxdepth: 2

--- a/docs/tutorials/storage.rst
+++ b/docs/tutorials/storage.rst
@@ -174,7 +174,7 @@ If you have Python installed on the computer you use to program your BBC
 micro:bit then you can use a special utility called ``microfs`` (shortened to
 ``ufs`` when using it in the command line). Full instructions for installing
 and using all the features of microfs can be found
-`in its documentation <http://microfs.rtfd.org>`_.
+`in its documentation <https://microfs.readthedocs.io>`_.
 
 Nevertheless it's possible to do most of the things you need with just four
 simple commands::

--- a/source/microbit/help.c
+++ b/source/microbit/help.c
@@ -58,7 +58,7 @@ STATIC const char *help_text =
 "\n"
 "For more information about Python, visit: http://python.org/\n"
 "To find out about MicroPython, visit: http://micropython.org/\n"
-"Python/micro:bit documentation is here: http://microbit-micropython.rtfd.org/\n"
+"Python/micro:bit documentation is here: https://microbit-micropython.readthedocs.io/\n"
 ;
 
 typedef struct _mp_doc_t {


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.