### PR TITLE
Fixup file system. Fixes #318  and #355

### DIFF
--- a/source/microbit/fileobj.c
+++ b/source/microbit/fileobj.c
@@ -52,7 +52,20 @@ STATIC mp_obj_t file___exit__(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(file___exit___obj, 4, 4, file___exit__);
 
-static const mp_map_elem_t microbit_file_locals_dict_table[] = {
+static const mp_map_elem_t microbit_textio_locals_dict_table[] = {
+    { MP_OBJ_NEW_QSTR(MP_QSTR_close), (mp_obj_t)&microbit_file_close_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_name), (mp_obj_t)&microbit_file_name_obj },
+    { MP_ROM_QSTR(MP_QSTR___enter__), (mp_obj_t)&mp_identity_obj },
+    { MP_ROM_QSTR(MP_QSTR___exit__), (mp_obj_t)&file___exit___obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_writable), (mp_obj_t)&microbit_file_writable_obj },
+    /* Stream methods */
+    { MP_OBJ_NEW_QSTR(MP_QSTR_read), (mp_obj_t)&mp_stream_read_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_readline), (mp_obj_t)&mp_stream_unbuffered_readline_obj},
+    { MP_OBJ_NEW_QSTR(MP_QSTR_write), (mp_obj_t)&mp_stream_write_obj },
+};
+static MP_DEFINE_CONST_DICT(microbit_textio_locals_dict, microbit_textio_locals_dict_table);
+
+static const mp_map_elem_t microbit_bytesio_locals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_close), (mp_obj_t)&microbit_file_close_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_name), (mp_obj_t)&microbit_file_name_obj },
     { MP_ROM_QSTR(MP_QSTR___enter__), (mp_obj_t)&mp_identity_obj },
@@ -61,10 +74,9 @@ static const mp_map_elem_t microbit_file_locals_dict_table[] = {
     /* Stream methods */
     { MP_OBJ_NEW_QSTR(MP_QSTR_read), (mp_obj_t)&mp_stream_read_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_readinto), (mp_obj_t)&mp_stream_readinto_obj },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_readline), (mp_obj_t)&mp_stream_unbuffered_readline_obj},
     { MP_OBJ_NEW_QSTR(MP_QSTR_write), (mp_obj_t)&mp_stream_write_obj },
 };
-static MP_DEFINE_CONST_DICT(microbit_file_locals_dict, microbit_file_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_bytesio_locals_dict, microbit_bytesio_locals_dict_table);
 
 STATIC const mp_stream_p_t bytesio_stream_p = {
     .read = microbit_file_read,
@@ -86,7 +98,7 @@ const mp_obj_type_t microbit_bytesio_type = {
     .buffer_p = {NULL},
     .stream_p = &bytesio_stream_p,
     .bases_tuple = NULL,
-    .locals_dict = (mp_obj_dict_t*)&microbit_file_locals_dict,
+    .locals_dict = (mp_obj_dict_t*)&microbit_bytesio_locals_dict,
 };
 
 STATIC const mp_stream_p_t textio_stream_p = {
@@ -110,7 +122,7 @@ const mp_obj_type_t microbit_textio_type = {
     .buffer_p = {NULL},
     .stream_p = &textio_stream_p,
     .bases_tuple = NULL,
-    .locals_dict = (mp_obj_dict_t*)&microbit_file_locals_dict,
+    .locals_dict = (mp_obj_dict_t*)&microbit_textio_locals_dict,
 };
 
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -83,18 +83,17 @@ def test_text_file():
     os.remove("test2.txt")
     assert not os.listdir()
 
-
 def test_many_files():
-    for i in range(100):
+    for i in range(80):
         name = "%d.dat" % i
         write_data_to_file(name, i*3, 16, 4)
         verify_file(name, data_stream(i*3), 16, 4, 'b')
-    for i in range(100):
+    for i in range(80):
         os.remove("%d.dat" % i)
         name = "_%d.dat" % i
         write_data_to_file(name, i*3, 16, 4)
         verify_file(name, data_stream(i*3), 16, 4, 'b')
-    for i in range(100):
+    for i in range(80):
         os.remove("_%d.dat" % i)
     assert not os.listdir()
 

--- a/tests/test_files2.py
+++ b/tests/test_files2.py
@@ -49,18 +49,18 @@ def clear_files():
         os.remove(f)
 
 def test_interleaved_small_files():
-    for i in range(100):
+    for i in range(80):
         name = "%d.dat" % i
         write_data_to_file(name, i*3, 16, 6)
-    for i in range(0, 100, 2):
+    for i in range(0, 80, 2):
         os.remove("%d.dat" % i)
-    for i in range(100, 150):
+    for i in range(80, 120):
         name = "%d.dat" % i
         write_data_to_file(name, i*3, 16, 6)
         verify_file(name, data_stream(i*3), 16, 6, 'b')
-    for i in range(1, 100, 2):
+    for i in range(1, 80, 2):
         os.remove("%d.dat" % i)
-    for i in range(100, 150):
+    for i in range(80, 120):
         os.remove("%d.dat" % i)
     assert not os.listdir()
 
@@ -70,21 +70,21 @@ def test_interleaved_large_files():
         out_buf[i] = 100-i
     with open("test1.dat", "wb") as fd1:
         with open("test2.dat", "wb") as fd2:
-            for i in range(90):
+            for i in range(60):
                 fd1.write(out_buf)
                 fd2.write(out_buf)
     os.remove("test2.dat")
     with open("test3.dat", "wb") as fd3:
-        for i in range(90):
+        for i in range(60):
             fd3.write(out_buf)
     assert sorted(os.listdir()) == [ "test1.dat", "test3.dat" ]
     in_buf = bytearray(100)
     with open("test1.dat", "rb") as fd:
-        for i in range(90):
+        for i in range(60):
             fd.readinto(in_buf)
             assert in_buf == out_buf
     with open("test3.dat", "rb") as fd:
-        for i in range(90):
+        for i in range(60):
             fd.readinto(in_buf)
             assert in_buf == out_buf
 

--- a/tests/test_files3.py
+++ b/tests/test_files3.py
@@ -5,39 +5,39 @@ from microbit import display, Image
 #We don't have space for Beowolf, so here's the next best thing...
 text = """
 ’Twas brillig, and the slithy toves
-      Did gyre and gimble in the wabe:
+  Did gyre and gimble in the wabe:
 All mimsy were the borogoves,
-      And the mome raths outgrabe.
+  And the mome raths outgrabe.
 
 “Beware the Jabberwock, my son!
-      The jaws that bite, the claws that catch!
+  The jaws that bite, the claws that catch!
 Beware the Jubjub bird, and shun
-      The frumious Bandersnatch!”
+ The frumious Bandersnatch!”
 
 He took his vorpal sword in hand;
-      Long time the manxome foe he sought—
+  Long time the manxome foe he sought—
 So rested he by the Tumtum tree
-      And stood awhile in thought.
+  And stood awhile in thought.
 
 And, as in uffish thought he stood,
-      The Jabberwock, with eyes of flame,
+  The Jabberwock, with eyes of flame,
 Came whiffling through the tulgey wood,
-      And burbled as it came!
+  And burbled as it came!
 
 One, two! One, two! And through and through
-      The vorpal blade went snicker-snack!
+  The vorpal blade went snicker-snack!
 He left it dead, and with its head
-      He went galumphing back.
+  He went galumphing back.
 
 “And hast thou slain the Jabberwock?
-      Come to my arms, my beamish boy!
+  Come to my arms, my beamish boy!
 O frabjous day! Callooh! Callay!”
-      He chortled in his joy.
+  He chortled in his joy.
 
 ’Twas brillig, and the slithy toves
-      Did gyre and gimble in the wabe:
+  Did gyre and gimble in the wabe:
 All mimsy were the borogoves,
-      And the mome raths outgrabe.
+  And the mome raths outgrabe.
 """
 
 def test_read_while_writing():
@@ -73,11 +73,17 @@ def test_removing_mid_write():
     except OSError:
         pass
 
+def test_repeated_write():
+    for i in range(40):
+        with open("jabbawocky.txt", "w") as j:
+            j.write(text)
+
 display.clear()
 try:
     test_read_while_writing()
     test_removing_mid_read()
     test_removing_mid_write()
+    test_repeated_write()
     print("File test: PASS")
     display.show(Image.HAPPY)
 except Exception as ae:


### PR DESCRIPTION
Remove incorrect method on bytes/textio classes.
Fix repeated write to the same file.

I've also had to reduce the number and sizes of files in the tests to make up for reduced space as a result of larger executable. Mainly the speech module, I expect.