### PR TITLE
Update DAL to v1.4.19b.

### DIFF
--- a/module.json
+++ b/module.json
@@ -8,7 +8,7 @@
   "homepage": "http://micropython.org",
   "dependencies":{
     "mbed-classic": "~0.0.4",
-    "microbit-dal":"lancaster-university/microbit-dal#v1.4.19"
+    "microbit-dal":"lancaster-university/microbit-dal#v1.4.19b"
   },
   "extraIncludes":[
     "inc",


### PR DESCRIPTION
This fixes a compile issue with the ble-nrf51822 component.

Will fix #338.