### PR TITLE
Fix touch sensing for pins.

### DIFF
--- a/source/microbit/microbitbutton.cpp
+++ b/source/microbit/microbitbutton.cpp
@@ -46,7 +46,7 @@ static bool debounced_high[8] = { true, true, true, true, true, true, true, true
 mp_obj_t microbit_button_is_pressed(mp_obj_t self_in) {
     microbit_button_obj_t *self = (microbit_button_obj_t*)self_in;
     /* Button is pressed if pin is low */
-    return mp_obj_new_bool(!debounced_high[self->pin->number]);
+    return mp_obj_new_bool(!debounced_high[self->pin->number&7]);
 }
 MP_DEFINE_CONST_FUN_OBJ_1(microbit_button_is_pressed_obj, microbit_button_is_pressed);
 

--- a/source/microbit/microbitpin.cpp
+++ b/source/microbit/microbitpin.cpp
@@ -281,7 +281,7 @@ mp_obj_t microbit_pin_is_touched(mp_obj_t self_in) {
     qstr mode = microbit_obj_pin_get_mode(self);
     if (mode != MP_QSTR_touch && mode != MP_QSTR_button) {
         microbit_obj_pin_acquire(self, MP_QSTR_touch);
-        nrf_gpio_cfg_input(self->name, NRF_GPIO_PIN_PULLUP);
+        nrf_gpio_cfg_input(self->name, NRF_GPIO_PIN_NOPULL);
     }
     /* Pin is touched if it is low after debouncing */
     return mp_obj_new_bool(!microbit_pin_high_debounced(self));


### PR DESCRIPTION
Use NO_PULL for touch pins.
The internal 11k resistor is a better conductor than I am, so `pin0.is_touched()` always returns false.
Using the external 1MΩ means that a sufficiently firm press while earthed does work (just).

http://tech.microbit.org/hardware/schematic/
