### PR TITLE
Change default pin states to allow for digital use.

### DIFF
--- a/source/microbit/microbitpin.cpp
+++ b/source/microbit/microbitpin.cpp
@@ -50,14 +50,14 @@ static const qstr initial_modes[] = {
     MP_QSTR_display, /* pin 10 */
     MP_QSTR_button,  /* pin 11 - button B */
     MP_QSTR_unused,  /* pin 12 */
-    MP_QSTR_spi,     /* pin 13 */
-    MP_QSTR_spi,     /* pin 14 */
-    MP_QSTR_spi,     /* pin 15 */
+    MP_QSTR_unused,  /* pin 13 */
+    MP_QSTR_unused,  /* pin 14 */
+    MP_QSTR_unused,  /* pin 15 */
     MP_QSTR_unused,  /* pin 16 */
     MP_QSTR_3v,      /* pin 17 - 3V */
     MP_QSTR_3v,      /* pin 18 - 3V */
-    MP_QSTR_i2c,     /* pin 19 */
-    MP_QSTR_i2c,     /* pin 20 */
+    MP_QSTR_unused,  /* pin 19 */
+    MP_QSTR_unused,  /* pin 20 */
     MP_QSTR_stop     /* Sentinel value to mark end of array */
 };
 


### PR DESCRIPTION
This is probably a bodge. *PLEASE CHECK*

When using a build of the latest master.  I try this in the REPL:

```
>>> from microbit import *
>>> pin14.write_digital(1)
```

I *should* be able to use pin14 as a digital pin (I've been sent a robotics kit that expects to be able to use `pin14` in this manner and our docs appear to say so too - see that table here: https://microbit-micropython.readthedocs.io/en/latest/pin.html). 

But instead I get:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Pin 14 in spi mode
```

Looking at `microbitpin.cpp` I notice that the `microbit_pin_write_digital` function attempts to acquire the pin in write digital mode. Unfortunately, I the `release` function assigned to pins in SPI mode appears to be `mode_error`. Hence the traceback we get above.

Put simply you can't transition out of the SPI state. This PR attempts to *bodge* the simplest solution by putting the SPI and I2C pins into a state from which one can transition.

*My concern is there's no way for the pins to get into SPI of I2C mode* that I can find. I guess this should happen when / if those modules are initialised with either referenced or default pins. However, a cursory look at the source appears to suggest such modes are not set against the pins even when non-default pins are used.

I understand why we probably don't want a state transition from spi to something else: you've got some sort of hardware necessarily plugged in. However, I guess if you don't you should be able to use the pins as their capabilities allow. This perhaps also applies to pins for buttons and display columns.

I don't expect this PR to be merged but it gives us two things:

1) The robot kit works (I've tried it).
2) It's somewhere for a discussion of the above.

Thoughts..? @markshannon @dpgeorge  