### PR TITLE
Fix radio docs: change default power to "6", which is 0 dBm.

### DIFF
--- a/docs/radio.rst
+++ b/docs/radio.rst
@@ -71,7 +71,7 @@ Functions
     via this channel will be put onto the incoming message queue. Each step is
     1MHz wide, based at 2400MHz.
 
-    The ``power`` (default=0) is an integer value from 0 to 7 (inclusive) to
+    The ``power`` (default=6) is an integer value from 0 to 7 (inclusive) to
     indicate the strength of signal used when broadcasting a message. The
     higher the value the stronger the signal, but the more power is consumed
     by the device. The numbering translates to positions in the following list


### PR DESCRIPTION
The default power level for radio is 0 dBm, which is "power=6" in the API.  This patch updates the docs to reflect this.

To whoever reviews this: please double check the code in source/microbit/modradio.cpp to check that I got this right, thanks!