### PR TITLE
Fix ValueError with music.pitch, also cleanup stopping code

### DIFF
--- a/inc/microbit/mpconfigport.h
+++ b/inc/microbit/mpconfigport.h
@@ -131,6 +131,11 @@ extern const struct _mp_obj_module_t speech_module;
     const struct _pwm_events *pwm_active_events; \
     const struct _pwm_events *pwm_pending_events; \
 
+
+// Enable/disable irqs to make sections of code atomic.
+#define MICROPY_BEGIN_ATOMIC_SECTION (__get_PRIMASK()); __set_PRIMASK(0)
+#define MICROPY_END_ATOMIC_SECTION(state) __set_PRIMASK(state)
+
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>
 

--- a/source/microbit/microbitmusic.cpp
+++ b/source/microbit/microbitmusic.cpp
@@ -281,17 +281,11 @@ STATIC mp_obj_t microbit_music_get_tempo(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(microbit_music_get_tempo_obj, microbit_music_get_tempo);
 
-STATIC mp_obj_t microbit_music_stop(mp_uint_t n_args, const mp_obj_t *args) {
-    const microbit_pin_obj_t *pin;
-    if (n_args == 0) {
-        pin = &microbit_p0_obj;
-    } else {
-        pin = microbit_obj_get_pin(args[0]);
-    }
+STATIC mp_obj_t microbit_music_stop(void) {
     music_stop();
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(microbit_music_stop_obj, 0, 1, microbit_music_stop);
+MP_DEFINE_CONST_FUN_OBJ_0(microbit_music_stop_obj, microbit_music_stop);
 
 STATIC mp_obj_t microbit_music_play(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {


### PR DESCRIPTION
Fixes issue #398, by stopping the current tone that is playing.

Factor out the code that stops the music playing into its own function, then call this from everywhere. This new version always ensures that async_music_pin is non-null when a pin has been configured in PWM mode. We use this information to know when we can reset/free the pin.

Since music playing now requires two variables to be consistent, we use the `MICROPY_{BEGIN,END}_ATOMIC_SECTION` macros to ensure that interrupts are not enabled during the critical section.

This commit also configures the atomic_section macros to disable interrupts, then return them to their previous state (to allow nested atomic sections).

NOTE: The current music code should now be safe, with its own interrupts... Though if some other code decided to try starting a song within an interrupt handler then weird things may happen. This can be fixed by moving the code that sets the async pin and the async mode.