### PR TITLE
Sort out pin modes and music module

### DIFF
--- a/inc/microbit/microbitobj.h
+++ b/inc/microbit/microbitobj.h
@@ -29,13 +29,8 @@
 extern "C" {
 
 #include "py/obj.h"
+#include "microbitpin.h"
 #include "PinNames.h"
-
-typedef struct _microbit_pin_obj_t {
-    mp_obj_base_t base;
-    uint8_t number; // The pin number on microbit board
-    PinName name; // The pin number in the GPIO port.
-} microbit_pin_obj_t;
 
 const microbit_pin_obj_t *microbit_obj_get_pin(mp_obj_t o);
 PinName microbit_obj_get_pin_name(mp_obj_t o);

--- a/source/microbit/microbitbutton.cpp
+++ b/source/microbit/microbitbutton.cpp
@@ -109,8 +109,6 @@ const microbit_button_obj_t microbit_button_b_obj = {
     .index = 1,
 };
 
-extern uint8_t microbit_pinmodes[];
-
 enum PinTransition
 {
     LOW_LOW = 0,
@@ -162,11 +160,11 @@ void microbit_button_tick(void) {
         pressed[microbit_button_a_obj.index] = (pressed[microbit_button_a_obj.index] + 2) | 1;
     if (update(microbit_button_b_obj.pin) == HIGH_LOW)
         pressed[microbit_button_b_obj.index] = (pressed[microbit_button_b_obj.index] + 2) | 1;
-    if (microbit_obj_pin_get_mode(&microbit_p0_obj) == MP_QSTR_touch)
+    if (microbit_pin_get_mode(&microbit_p0_obj) == microbit_pin_mode_touch)
         update(&microbit_p0_obj);
-    if (microbit_obj_pin_get_mode(&microbit_p1_obj) == MP_QSTR_touch)
+    if (microbit_pin_get_mode(&microbit_p1_obj) == microbit_pin_mode_touch)
         update(&microbit_p1_obj);
-    if (microbit_obj_pin_get_mode(&microbit_p2_obj) == MP_QSTR_touch)
+    if (microbit_pin_get_mode(&microbit_p2_obj) == microbit_pin_mode_touch)
         update(&microbit_p2_obj);
 }
 

--- a/source/microbit/microbitdisplay.cpp
+++ b/source/microbit/microbitdisplay.cpp
@@ -431,12 +431,12 @@ mp_obj_t microbit_display_on_func(mp_obj_t obj) {
     microbit_obj_pin_fail_if_cant_acquire(&microbit_p7_obj);
     microbit_obj_pin_fail_if_cant_acquire(&microbit_p9_obj);
     microbit_obj_pin_fail_if_cant_acquire(&microbit_p10_obj);
-    microbit_obj_pin_acquire(&microbit_p3_obj, MP_QSTR_display);
-    microbit_obj_pin_acquire(&microbit_p4_obj, MP_QSTR_display);
-    microbit_obj_pin_acquire(&microbit_p6_obj, MP_QSTR_display);
-    microbit_obj_pin_acquire(&microbit_p7_obj, MP_QSTR_display);
-    microbit_obj_pin_acquire(&microbit_p9_obj, MP_QSTR_display);
-    microbit_obj_pin_acquire(&microbit_p10_obj, MP_QSTR_display);
+    microbit_obj_pin_acquire(&microbit_p3_obj, microbit_pin_mode_display);
+    microbit_obj_pin_acquire(&microbit_p4_obj, microbit_pin_mode_display);
+    microbit_obj_pin_acquire(&microbit_p6_obj, microbit_pin_mode_display);
+    microbit_obj_pin_acquire(&microbit_p7_obj, microbit_pin_mode_display);
+    microbit_obj_pin_acquire(&microbit_p9_obj, microbit_pin_mode_display);
+    microbit_obj_pin_acquire(&microbit_p10_obj, microbit_pin_mode_display);
     /* Make sure all pins are in the correct state */
     microbit_display_init();
     /* Re-enable the display loop.  This will resume any animations in

--- a/source/microbit/microbitpin.cpp
+++ b/source/microbit/microbitpin.cpp
@@ -36,123 +36,33 @@ extern "C" {
 #include "nrf_gpio.h"
 #include "py/mphal.h"
 
-static const qstr initial_modes[] = {
-    MP_QSTR_unused,  /* pin 0 */
-    MP_QSTR_unused,  /* pin 1 */
-    MP_QSTR_unused,  /* pin 2 */
-    MP_QSTR_display, /* pin 3 */
-    MP_QSTR_display, /* pin 4 */
-    MP_QSTR_button,  /* pin 5 - button A */
-    MP_QSTR_display, /* pin 6 */
-    MP_QSTR_display, /* pin 7 */
-    MP_QSTR_unused,  /* pin 8 */
-    MP_QSTR_display, /* pin 9 */
-    MP_QSTR_display, /* pin 10 */
-    MP_QSTR_button,  /* pin 11 - button B */
-    MP_QSTR_unused,  /* pin 12 */
-    MP_QSTR_spi,     /* pin 13 */
-    MP_QSTR_spi,     /* pin 14 */
-    MP_QSTR_spi,     /* pin 15 */
-    MP_QSTR_unused,  /* pin 16 */
-    MP_QSTR_3v,      /* pin 17 - 3V */
-    MP_QSTR_3v,      /* pin 18 - 3V */
-    MP_QSTR_i2c,     /* pin 19 */
-    MP_QSTR_i2c,     /* pin 20 */
-    MP_QSTR_stop     /* Sentinel value to mark end of array */
-};
 
-uint8_t microbit_pinmodes[24];
+const microbit_pin_obj_t microbit_p0_obj = {{&microbit_touch_pin_type}, 0, MICROBIT_PIN_P0, MODE_UNUSED};
+const microbit_pin_obj_t microbit_p1_obj = {{&microbit_touch_pin_type}, 1, MICROBIT_PIN_P1, MODE_UNUSED};
+const microbit_pin_obj_t microbit_p2_obj = {{&microbit_touch_pin_type}, 2, MICROBIT_PIN_P2, MODE_UNUSED};
+const microbit_pin_obj_t microbit_p3_obj = {{&microbit_ad_pin_type},   3,  MICROBIT_PIN_P3, MODE_DISPLAY};
+const microbit_pin_obj_t microbit_p4_obj = {{&microbit_ad_pin_type},   4,  MICROBIT_PIN_P4, MODE_DISPLAY};
+const microbit_pin_obj_t microbit_p5_obj = {{&microbit_dig_pin_type},  5,  MICROBIT_PIN_P5, MODE_BUTTON};
+const microbit_pin_obj_t microbit_p6_obj = {{&microbit_dig_pin_type},  6,  MICROBIT_PIN_P6, MODE_DISPLAY};
+const microbit_pin_obj_t microbit_p7_obj = {{&microbit_dig_pin_type},  7,  MICROBIT_PIN_P7, MODE_DISPLAY};
+const microbit_pin_obj_t microbit_p8_obj = {{&microbit_dig_pin_type},  8,  MICROBIT_PIN_P8, MODE_UNUSED};
+const microbit_pin_obj_t microbit_p9_obj = {{&microbit_dig_pin_type},  9,  MICROBIT_PIN_P9, MODE_DISPLAY};
+const microbit_pin_obj_t microbit_p10_obj = {{&microbit_ad_pin_type},  10, MICROBIT_PIN_P10, MODE_DISPLAY};
+const microbit_pin_obj_t microbit_p11_obj = {{&microbit_dig_pin_type}, 11, MICROBIT_PIN_P11, MODE_BUTTON};
+const microbit_pin_obj_t microbit_p12_obj = {{&microbit_dig_pin_type}, 12, MICROBIT_PIN_P12, MODE_UNUSED};
+const microbit_pin_obj_t microbit_p13_obj = {{&microbit_dig_pin_type}, 13, MICROBIT_PIN_P13, MODE_SPI};
+const microbit_pin_obj_t microbit_p14_obj = {{&microbit_dig_pin_type}, 14, MICROBIT_PIN_P14, MODE_SPI};
+const microbit_pin_obj_t microbit_p15_obj = {{&microbit_dig_pin_type}, 15, MICROBIT_PIN_P15, MODE_SPI};
+const microbit_pin_obj_t microbit_p16_obj = {{&microbit_dig_pin_type}, 16, MICROBIT_PIN_P16, MODE_UNUSED};
+const microbit_pin_obj_t microbit_p19_obj = {{&microbit_dig_pin_type}, 19, MICROBIT_PIN_P19, MODE_I2C};
+const microbit_pin_obj_t microbit_p20_obj = {{&microbit_dig_pin_type}, 20, MICROBIT_PIN_P20, MODE_I2C};
 
 
-static void noop(const microbit_pin_obj_t *pin) {
-    (void)pin;
-}
-
-static void mode_error(const microbit_pin_obj_t *pin);
-
-static void analog_release(const microbit_pin_obj_t *pin) {
-    pwm_release(pin->name);
-}
-
-static const microbit_pinmode_t pinmodes[] = {
-    {
-        MP_QSTR_unused, noop,
-    },
-    {
-        MP_QSTR_write_analog, analog_release,
-    },
-    {
-        MP_QSTR_read_digital, noop,
-    },
-    {
-        MP_QSTR_write_digital, noop,
-    },
-    {
-        MP_QSTR_display, mode_error,
-    },
-    {
-        MP_QSTR_button, mode_error,
-    },
-    {
-        MP_QSTR_music, mode_error,
-    },
-    {
-        MP_QSTR_touch, noop,
-    },
-    {
-        MP_QSTR_audio_play, mode_error,
-    },
-    {
-        MP_QSTR_i2c, mode_error,
-    },
-    {
-        MP_QSTR_spi, mode_error,
-    },
-    // Add any new pin modes here
-    {
-        MP_QSTR_3v, mode_error, /* This miust be the end of the array as it acts as a sentinel */
-    },
-};
-
-#define DEBUG 0
-
-static const microbit_pinmode_t *mode_for_pin(const microbit_pin_obj_t *pin) {
-    uint8_t pinmode = microbit_pinmodes[pin->number];
-#if DEBUG
-    if (pinmode >= sizeof(pinmodes)/sizeof(microbit_pinmode_t)) {
-        mp_hal_display_string("Illegal pinmode");
-        return &pinmodes[0];
-    }
-#endif
-    return &pinmodes[pinmode];
-}
-
-static void mode_error(const microbit_pin_obj_t *pin) {
-    const microbit_pinmode_t *current_mode = mode_for_pin(pin);
-    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Pin %d in %q mode", pin->number, current_mode->name));
-}
-
-void set_mode(uint32_t pin, qstr name) {
-    for (uint32_t index = 0;; index++) {
-        if (pinmodes[index].name == name) {
-            microbit_pinmodes[pin] = index;
-            return;
-        }
-        if (pinmodes[index].name == MP_QSTR_3v) {
-            nlr_raise(mp_obj_new_exception_msg(&mp_type_AssertionError, "illegal mode name"));
-        }
-    }
-}
-
-qstr microbit_obj_pin_get_mode(const microbit_pin_obj_t *pin) {
-    return mode_for_pin(pin)->name;
-}
-
-mp_obj_t microbit_pin_get_mode(mp_obj_t self_in) {
+static mp_obj_t microbit_pin_get_mode_func(mp_obj_t self_in) {
     microbit_pin_obj_t *self = (microbit_pin_obj_t*)self_in;
-    return MP_OBJ_NEW_QSTR(microbit_obj_pin_get_mode(self));
+    return MP_OBJ_NEW_QSTR(microbit_pin_get_mode(self)->name);
 }
-MP_DEFINE_CONST_FUN_OBJ_1(microbit_pin_get_mode_obj, microbit_pin_get_mode);
+MP_DEFINE_CONST_FUN_OBJ_1(microbit_pin_get_mode_obj, microbit_pin_get_mode_func);
 
 mp_obj_t microbit_pin_write_digital(mp_obj_t self_in, mp_obj_t value_in) {
     microbit_pin_obj_t *self = (microbit_pin_obj_t*)self_in;
@@ -160,8 +70,8 @@ mp_obj_t microbit_pin_write_digital(mp_obj_t self_in, mp_obj_t value_in) {
     if (val >> 1) {
         nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "value must be 0 or 1"));
     }
-    if (microbit_obj_pin_get_mode(self) != MP_QSTR_write_digital) {
-        microbit_obj_pin_acquire(self, MP_QSTR_write_digital);
+    if (microbit_pin_get_mode(self) != microbit_pin_mode_write_digital) {
+        microbit_obj_pin_acquire(self, microbit_pin_mode_write_digital);
         nrf_gpio_cfg_output(self->name);
     }
     if (val)
@@ -174,8 +84,8 @@ MP_DEFINE_CONST_FUN_OBJ_2(microbit_pin_write_digital_obj, microbit_pin_write_dig
 
 mp_obj_t microbit_pin_read_digital(mp_obj_t self_in) {
     microbit_pin_obj_t *self = (microbit_pin_obj_t*)self_in;
-    if (microbit_obj_pin_get_mode(self) != MP_QSTR_read_digital) {
-        microbit_obj_pin_acquire(self, MP_QSTR_read_digital);
+    if (microbit_pin_get_mode(self) != microbit_pin_mode_read_digital) {
+        microbit_obj_pin_acquire(self, microbit_pin_mode_read_digital);
         nrf_gpio_cfg_input(self->name, NRF_GPIO_PIN_PULLDOWN);
     }
     return mp_obj_new_int(nrf_gpio_pin_read(self->name));
@@ -191,10 +101,10 @@ mp_obj_t microbit_pin_set_pull(mp_obj_t self_in, mp_obj_t pull_in) {
     if (((1 << pull) & SHIFT_PULL_MASK) == 0) {
         nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "invalid pull"));
     }
-    qstr mode = microbit_obj_pin_get_mode(self);
+    const microbit_pinmode_t *mode = microbit_pin_get_mode(self);
     /* Pull only applies in an read digital mode */
-    if (mode != MP_QSTR_read_digital) {
-        mode_error(self);
+    if (mode != microbit_pin_mode_read_digital) {
+        pinmode_error(self);
     }
     nrf_gpio_cfg_input(self->name, (nrf_gpio_pin_pull_t)pull);
     return mp_const_none;
@@ -205,10 +115,10 @@ MP_DEFINE_CONST_FUN_OBJ_2(microbit_pin_set_pull_obj, microbit_pin_set_pull);
 
 mp_obj_t microbit_pin_get_pull(mp_obj_t self_in) {
     microbit_pin_obj_t *self = (microbit_pin_obj_t*)self_in;
-    qstr mode = microbit_obj_pin_get_mode(self);
+    const microbit_pinmode_t *mode = microbit_pin_get_mode(self);
     /* Pull only applies in an read digital mode */
-    if (mode != MP_QSTR_read_digital) {
-        mode_error(self);
+    if (mode != microbit_pin_mode_read_digital) {
+        pinmode_error(self);
     }
     uint32_t pull = (NRF_GPIO->PIN_CNF[self->name] >> GPIO_PIN_CNF_PULL_Pos) & PULL_MASK;
     return mp_obj_new_int(pull);
@@ -227,22 +137,22 @@ mp_obj_t microbit_pin_write_analog(mp_obj_t self_in, mp_obj_t value_in) {
     if (set_value < 0 || set_value > MICROBIT_PIN_MAX_OUTPUT) {
         nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "value must be between 0 and 1023"));
     }
-    if (microbit_obj_pin_get_mode(self) != MP_QSTR_write_analog) {
-        microbit_obj_pin_acquire(self, MP_QSTR_write_analog);
+    if (microbit_pin_get_mode(self) != microbit_pin_mode_write_analog) {
+        microbit_obj_pin_acquire(self, microbit_pin_mode_write_analog);
         nrf_gpio_cfg_output(self->name);
     }
     pwm_set_duty_cycle(self->name, set_value);
     if (set_value == 0)
-        microbit_obj_pin_acquire(self, MP_QSTR_unused);
+        microbit_obj_pin_acquire(self, microbit_pin_mode_unused);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_2(microbit_pin_write_analog_obj, microbit_pin_write_analog);
 
 mp_obj_t microbit_pin_read_analog(mp_obj_t self_in) {
     microbit_pin_obj_t *self = (microbit_pin_obj_t*)self_in;
-    microbit_obj_pin_acquire(self, MP_QSTR_unused);
+    microbit_obj_pin_acquire(self, microbit_pin_mode_unused);
     analogin_t obj;
-    analogin_init(&obj, self->name);
+    analogin_init(&obj, (PinName)self->name);
     int val = analogin_read_u16(&obj);
     NRF_ADC->ENABLE = ADC_ENABLE_ENABLE_Disabled;
     return mp_obj_new_int(val);
@@ -278,10 +188,10 @@ MP_DEFINE_CONST_FUN_OBJ_1(microbit_pin_get_analog_period_microseconds_obj, micro
 
 mp_obj_t microbit_pin_is_touched(mp_obj_t self_in) {
     microbit_pin_obj_t *self = (microbit_pin_obj_t*)self_in;
-    qstr mode = microbit_obj_pin_get_mode(self);
-    if (mode != MP_QSTR_touch && mode != MP_QSTR_button) {
-        microbit_obj_pin_acquire(self, MP_QSTR_touch);
-        nrf_gpio_cfg_input(self->name, NRF_GPIO_PIN_NOPULL);
+    const microbit_pinmode_t *mode = microbit_pin_get_mode(self);
+    if (mode != microbit_pin_mode_touch && mode != microbit_pin_mode_button) {
+        microbit_obj_pin_acquire(self, microbit_pin_mode_touch);
+        nrf_gpio_cfg_input(self->name, NRF_GPIO_PIN_PULLUP);
     }
     /* Pin is touched if it is low after debouncing */
     return mp_obj_new_bool(!microbit_pin_high_debounced(self));
@@ -392,58 +302,12 @@ const mp_obj_type_t microbit_touch_pin_type = {
     .locals_dict = (mp_obj_dict_t*)&microbit_touch_pin_locals_dict,
 };
 
-const microbit_pin_obj_t microbit_p0_obj = {{&microbit_touch_pin_type}, 0, MICROBIT_PIN_P0};
-const microbit_pin_obj_t microbit_p1_obj = {{&microbit_touch_pin_type}, 1, MICROBIT_PIN_P1};
-const microbit_pin_obj_t microbit_p2_obj = {{&microbit_touch_pin_type}, 2, MICROBIT_PIN_P2};
-const microbit_pin_obj_t microbit_p3_obj = {{&microbit_ad_pin_type},   3,  MICROBIT_PIN_P3};
-const microbit_pin_obj_t microbit_p4_obj = {{&microbit_ad_pin_type},   4,  MICROBIT_PIN_P4};
-const microbit_pin_obj_t microbit_p5_obj = {{&microbit_dig_pin_type},  5,  MICROBIT_PIN_P5};
-const microbit_pin_obj_t microbit_p6_obj = {{&microbit_dig_pin_type},  6,  MICROBIT_PIN_P6};
-const microbit_pin_obj_t microbit_p7_obj = {{&microbit_dig_pin_type},  7,  MICROBIT_PIN_P7};
-const microbit_pin_obj_t microbit_p8_obj = {{&microbit_dig_pin_type},  8,  MICROBIT_PIN_P8};
-const microbit_pin_obj_t microbit_p9_obj = {{&microbit_dig_pin_type},  9,  MICROBIT_PIN_P9};
-const microbit_pin_obj_t microbit_p10_obj = {{&microbit_ad_pin_type},  10, MICROBIT_PIN_P10};
-const microbit_pin_obj_t microbit_p11_obj = {{&microbit_dig_pin_type}, 11, MICROBIT_PIN_P11};
-const microbit_pin_obj_t microbit_p12_obj = {{&microbit_dig_pin_type}, 12, MICROBIT_PIN_P12};
-const microbit_pin_obj_t microbit_p13_obj = {{&microbit_dig_pin_type}, 13, MICROBIT_PIN_P13};
-const microbit_pin_obj_t microbit_p14_obj = {{&microbit_dig_pin_type}, 14, MICROBIT_PIN_P14};
-const microbit_pin_obj_t microbit_p15_obj = {{&microbit_dig_pin_type}, 15, MICROBIT_PIN_P15};
-const microbit_pin_obj_t microbit_p16_obj = {{&microbit_dig_pin_type}, 16, MICROBIT_PIN_P16};
-const microbit_pin_obj_t microbit_p19_obj = {{&microbit_dig_pin_type}, 19, MICROBIT_PIN_P19};
-const microbit_pin_obj_t microbit_p20_obj = {{&microbit_dig_pin_type}, 20, MICROBIT_PIN_P20};
-
 
 void microbit_pin_init(void) {
     nrf_gpio_cfg_input(microbit_p5_obj.name, NRF_GPIO_PIN_PULLUP);
     nrf_gpio_cfg_input(microbit_p11_obj.name, NRF_GPIO_PIN_PULLUP);
-    for (uint32_t pin = 0;; pin++) {
-        if (initial_modes[pin] == MP_QSTR_stop)
-            return;
-        set_mode(pin, initial_modes[pin]);
-    }
 }
 
-void microbit_obj_pin_fail_if_cant_acquire(const microbit_pin_obj_t *pin) {
-    const microbit_pinmode_t *current_mode = mode_for_pin(pin);
-    if (current_mode->release == mode_error) {
-        mode_error(pin);
-    }
-}
-
-void microbit_obj_pin_free(const microbit_pin_obj_t *pin) {
-    set_mode(pin->number, MP_QSTR_unused);
-}
-
-bool microbit_obj_pin_can_be_acquired(const microbit_pin_obj_t *pin) {
-    const microbit_pinmode_t *current_mode = mode_for_pin(pin);
-    return current_mode->release != NULL;
-}
-
-void microbit_obj_pin_acquire(const microbit_pin_obj_t *pin, qstr new_mode) {
-    const microbit_pinmode_t *current_mode = mode_for_pin(pin);
-    current_mode->release(pin);
-    set_mode(pin->number, new_mode);
-}
 
 const microbit_pin_obj_t *microbit_obj_get_pin(mp_obj_t o) {
     mp_obj_type_t *type = mp_obj_get_type(o);
@@ -455,7 +319,7 @@ const microbit_pin_obj_t *microbit_obj_get_pin(mp_obj_t o) {
 }
 
 PinName microbit_obj_get_pin_name(mp_obj_t o) {
-    return microbit_obj_get_pin(o)->name;
+    return (PinName)microbit_obj_get_pin(o)->name;
 }
 
 }

--- a/source/microbit/microbitpinmode.c
+++ b/source/microbit/microbitpinmode.c
@@ -1,0 +1,108 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "microbit/microbitpin.h"
+#include "lib/pwm.h"
+
+uint8_t microbit_pinmode_indices[32] = { 0 };
+
+
+#define DEBUG 0
+
+const microbit_pinmode_t *microbit_pin_get_mode(const microbit_pin_obj_t *pin) {
+    uint8_t pinmode = microbit_pinmode_indices[pin->number];
+    if (pinmode == 0) {
+        pinmode = pin->initial_mode;
+    }
+#if DEBUG
+    if (pinmode >= sizeof(microbit_pinmodes)/sizeof(microbit_pinmode_t)) {
+        mp_hal_display_string("Illegal pinmode");
+        return &microbit_pinmodes[0];
+    }
+#endif
+    return &microbit_pinmodes[pinmode];
+}
+
+static void set_mode(uint32_t pin, const microbit_pinmode_t *mode) {
+    uint32_t index = mode - &microbit_pinmodes[0];
+    microbit_pinmode_indices[pin] = index;
+    return;
+}
+
+
+void microbit_obj_pin_fail_if_cant_acquire(const microbit_pin_obj_t *pin) {
+    const microbit_pinmode_t *current_mode = microbit_pin_get_mode(pin);
+    if (current_mode->release == pinmode_error) {
+        pinmode_error(pin);
+    }
+}
+
+void microbit_obj_pin_free(const microbit_pin_obj_t *pin) {
+    if (pin != NULL) {
+        set_mode(pin->number, microbit_pin_mode_unused);
+    }
+}
+
+bool microbit_obj_pin_can_be_acquired(const microbit_pin_obj_t *pin) {
+    const microbit_pinmode_t *current_mode = microbit_pin_get_mode(pin);
+    return current_mode->release != pinmode_error;
+}
+
+void microbit_obj_pin_acquire(const microbit_pin_obj_t *pin, const microbit_pinmode_t *new_mode) {
+    const microbit_pinmode_t *current_mode = microbit_pin_get_mode(pin);
+    if (current_mode != new_mode) {
+        current_mode->release(pin);
+        set_mode(pin->number, new_mode);
+    }
+}
+
+static void noop(const microbit_pin_obj_t *pin) {
+    (void)pin;
+}
+
+void pinmode_error(const microbit_pin_obj_t *pin) {
+    const microbit_pinmode_t *current_mode = microbit_pin_get_mode(pin);
+    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Pin %d in %q mode", pin->number, current_mode->name));
+}
+
+static void analog_release(const microbit_pin_obj_t *pin) {
+    pwm_release(pin->name);
+}
+
+const microbit_pinmode_t microbit_pinmodes[] = {
+    [MODE_UNUSED]        = { MP_QSTR_unused, noop },
+    [MODE_WRITE_ANALOG]  = { MP_QSTR_write_analog, analog_release },
+    [MODE_READ_DIGITAL]  = { MP_QSTR_read_digital, noop },
+    [MODE_WRITE_DIGITAL] = { MP_QSTR_write_digital, noop },
+    [MODE_DISPLAY]       = { MP_QSTR_display, pinmode_error },
+    [MODE_BUTTON]        = { MP_QSTR_button, pinmode_error },
+    [MODE_MUSIC]         = { MP_QSTR_music, pinmode_error },
+    [MODE_AUDIO_PLAY]    = { MP_QSTR_audio, noop },
+    [MODE_TOUCH]         = { MP_QSTR_touch, pinmode_error },
+    [MODE_I2C]           = { MP_QSTR_i2c, pinmode_error },
+    [MODE_SPI]           = { MP_QSTR_spi, pinmode_error }
+};

--- a/source/microbit/microbitspi.cpp
+++ b/source/microbit/microbitspi.cpp
@@ -56,9 +56,9 @@ STATIC mp_obj_t microbit_spi_init(mp_uint_t n_args, const mp_obj_t *pos_args, mp
         MP_ARRAY_SIZE(allowed_args), allowed_args, (mp_arg_val_t*)&args);
 
     // get pins
-    PinName p_sclk = MICROBIT_PIN_P13;
-    PinName p_mosi = MICROBIT_PIN_P15;
-    PinName p_miso = MICROBIT_PIN_P14;
+    PinName p_sclk = (PinName)microbit_p13_obj.name;
+    PinName p_mosi = (PinName)microbit_p15_obj.name;
+    PinName p_miso = (PinName)microbit_p14_obj.name;
     if (args.sclk.u_obj != mp_const_none) {
         p_sclk = microbit_obj_get_pin_name(args.sclk.u_obj);
     }

--- a/source/microbit/microbituart.cpp
+++ b/source/microbit/microbituart.cpp
@@ -73,18 +73,18 @@ STATIC mp_obj_t microbit_uart_init(mp_uint_t n_args, const mp_obj_t *pos_args, m
 
     // set tx/rx pins if they are given
     if (args[5].u_obj != mp_const_none) {
-        p_tx = microbit_obj_get_pin(args[5].u_obj)->name;
+        p_tx = microbit_obj_get_pin_name(args[5].u_obj);
     }
     if (args[6].u_obj != mp_const_none) {
-        p_rx = microbit_obj_get_pin(args[6].u_obj)->name;
+        p_rx = microbit_obj_get_pin_name(args[6].u_obj);
     }
 
     // support for legacy "pins" argument
     if (args[4].u_obj != mp_const_none) {
         mp_obj_t *pins;
         mp_obj_get_array_fixed_n(args[4].u_obj, 2, &pins);
-        p_tx = microbit_obj_get_pin(pins[0])->name;
-        p_rx = microbit_obj_get_pin(pins[1])->name;
+        p_tx = microbit_obj_get_pin_name(pins[0]);
+        p_rx = microbit_obj_get_pin_name(pins[1]);
     }
 
     // initialise the uart

--- a/source/microbit/modaudio.cpp
+++ b/source/microbit/modaudio.cpp
@@ -64,7 +64,7 @@ static void disable_gpiote(uint8_t channel)
     nrf_gpiote_te_default(channel);
 }
 
-static void audio_gpiote_init(PinName pin, uint8_t channel)
+static void audio_gpiote_init(uint32_t pin, uint8_t channel)
 {
     DEBUG(("GPIOTE init. pin %d, channel %d\r\n", pin, channel));
     nrf_gpio_pin_clear(pin);
@@ -162,7 +162,7 @@ static int32_t audio_ticker(void);
 #define AUDIO_BUFFER_MASK (AUDIO_BUFFER_SIZE-1)
 
 static void init_pin(const microbit_pin_obj_t *p0) {
-    microbit_obj_pin_acquire(p0, MP_QSTR_audio_play);
+    microbit_obj_pin_acquire(p0, microbit_pin_mode_audio_play);
     pin0 = p0;
     nrf_gpio_pin_write(pin0->name, 0);
     audio_gpiote_init(pin0->name, 0);
@@ -172,8 +172,8 @@ static void init_pin(const microbit_pin_obj_t *p0) {
 
 static void init_pins(const microbit_pin_obj_t *p0, const microbit_pin_obj_t *p1) {
     microbit_obj_pin_fail_if_cant_acquire(p0);
-    microbit_obj_pin_acquire(p1, MP_QSTR_audio_play);
-    microbit_obj_pin_acquire(p0, MP_QSTR_audio_play);
+    microbit_obj_pin_acquire(p1, microbit_pin_mode_audio_play);
+    microbit_obj_pin_acquire(p0, microbit_pin_mode_audio_play);
     pin0 = p0;
     pin1 = p1;
     nrf_gpio_pin_write(pin0->name, 0);
@@ -349,15 +349,15 @@ static void audio_auto_set_pins(void) {
     bool usable[3];
     if (microbit_obj_pin_can_be_acquired(&microbit_p0_obj)) {
         usable[0] = true;
-        microbit_obj_pin_acquire(&microbit_p0_obj, MP_QSTR_unused);
+        microbit_obj_pin_acquire(&microbit_p0_obj, microbit_pin_mode_unused);
     }
     if (microbit_obj_pin_can_be_acquired(&microbit_p1_obj)) {
         usable[1] = true;
-        microbit_obj_pin_acquire(&microbit_p1_obj, MP_QSTR_unused);
+        microbit_obj_pin_acquire(&microbit_p1_obj, microbit_pin_mode_unused);
     }
     if (microbit_obj_pin_can_be_acquired(&microbit_p2_obj)) {
         usable[2] = true;
-        microbit_obj_pin_acquire(&microbit_p2_obj, MP_QSTR_unused);
+        microbit_obj_pin_acquire(&microbit_p2_obj, microbit_pin_mode_unused);
     }
     for (i = 0; i < 2; i++) {
         if (!usable[i])

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -1,0 +1,46 @@
+
+from microbit import display, Image, pin0, pin1, pin2, pin8
+import music
+
+PINS = pin0, pin1, pin2, pin8
+FREQS = 400, 500, 600, 700, 800, 900
+
+def test_rapid_pin_switch():
+    for i in range(20):
+        for pin in PINS:
+            music.play(music.NYAN, pin, wait=False)
+
+def test_rapid_pitch_switch():
+    for i in range(20):
+        for freq in FREQS:
+            music.pitch(freq, wait=False)
+
+def test_repeated_stop():
+    for i in range(20):
+        music.stop()
+
+def test_repeated_reset():
+    for i in range(20):
+        music.reset()
+
+def test_repeated_set_tempo():
+    for i in range(20):
+        music.set_tempo(ticks=i%4+1, bpm=i+100)
+
+def test_all_pins_free():
+    for pin in PINS:
+        pin.read_digital()
+
+display.clear()
+try:
+    test_rapid_pin_switch()
+    test_rapid_pitch_switch()
+    test_repeated_stop()
+    test_repeated_reset()
+    test_repeated_set_tempo()
+    test_all_pins_free()
+    print("File test: PASS")
+    display.show(Image.HAPPY)
+except Exception as ae:
+    display.show(Image.SAD)
+    raise


### PR DESCRIPTION
Fixes #398

This PR:

1. Changes pin-mode implementation to use pointers to structs, rather than strings. This should avoid any race conditions when releasing a pin in an interrupt handler.
2. Documents which pin-mode functions can and cannot be called in an interrupt handler.
3. Improves the pin-mode API doing the sensible thing when passed a NULL or attempting to re-acquire the same pin.
4. Fix music module's pin releasing.
5. Adds a test for the music module (just tests that it doesn't crash, not that it makes the right noises :musical_note: ).

Includes a revert of #399 and supersedes #403