### PR TITLE
SPI acquires pins only when initialized and methods raise if SPI is not initialized before use.

### DIFF
--- a/inc/microbit/microbitpin.h
+++ b/inc/microbit/microbitpin.h
@@ -69,6 +69,28 @@ extern const microbit_pinmode_t microbit_pinmodes[];
 #define microbit_pin_mode_i2c           (&microbit_pinmodes[MODE_I2C])
 #define microbit_pin_mode_spi           (&microbit_pinmodes[MODE_SPI])
 
+extern const microbit_pin_obj_t microbit_pins[];
+
+#define microbit_p0_obj microbit_pins[0]
+#define microbit_p1_obj microbit_pins[1]
+#define microbit_p2_obj microbit_pins[2]
+#define microbit_p3_obj microbit_pins[3]
+#define microbit_p4_obj microbit_pins[4]
+#define microbit_p5_obj microbit_pins[5]
+#define microbit_p6_obj microbit_pins[6]
+#define microbit_p7_obj microbit_pins[7]
+#define microbit_p8_obj microbit_pins[8]
+#define microbit_p9_obj microbit_pins[9]
+#define microbit_p10_obj microbit_pins[10]
+#define microbit_p11_obj microbit_pins[11]
+#define microbit_p12_obj microbit_pins[12]
+#define microbit_p13_obj microbit_pins[13]
+#define microbit_p14_obj microbit_pins[14]
+#define microbit_p15_obj microbit_pins[15]
+#define microbit_p16_obj microbit_pins[16]
+#define microbit_p19_obj microbit_pins[19]
+#define microbit_p20_obj microbit_pins[20]
+
 /** Can this pin be acquired? Safe to call in an interrupt. Not safe to call in an interrupt. */
 void microbit_obj_pin_fail_if_cant_acquire(const microbit_pin_obj_t *pin);
 
@@ -85,6 +107,8 @@ void microbit_obj_pin_acquire(const microbit_pin_obj_t *pin, const microbit_pinm
 bool microbit_pin_high_debounced(microbit_pin_obj_t *pin);
 
 const microbit_pinmode_t *microbit_pin_get_mode(const microbit_pin_obj_t *pin);
+
+const microbit_pin_obj_t *microbit_pin_from_number(uint32_t number);
 
 bool microbit_obj_pin_can_be_acquired(const microbit_pin_obj_t *pin);
 

--- a/inc/microbit/modmicrobit.h
+++ b/inc/microbit/modmicrobit.h
@@ -32,26 +32,6 @@ extern const mp_obj_type_t microbit_ad_pin_type;
 extern const mp_obj_type_t microbit_dig_pin_type;
 extern const mp_obj_type_t microbit_touch_pin_type;
 
-extern const struct _microbit_pin_obj_t microbit_p0_obj;
-extern const struct _microbit_pin_obj_t microbit_p1_obj;
-extern const struct _microbit_pin_obj_t microbit_p2_obj;
-extern const struct _microbit_pin_obj_t microbit_p3_obj;
-extern const struct _microbit_pin_obj_t microbit_p4_obj;
-extern const struct _microbit_pin_obj_t microbit_p5_obj;
-extern const struct _microbit_pin_obj_t microbit_p6_obj;
-extern const struct _microbit_pin_obj_t microbit_p7_obj;
-extern const struct _microbit_pin_obj_t microbit_p8_obj;
-extern const struct _microbit_pin_obj_t microbit_p9_obj;
-extern const struct _microbit_pin_obj_t microbit_p10_obj;
-extern const struct _microbit_pin_obj_t microbit_p11_obj;
-extern const struct _microbit_pin_obj_t microbit_p12_obj;
-extern const struct _microbit_pin_obj_t microbit_p13_obj;
-extern const struct _microbit_pin_obj_t microbit_p14_obj;
-extern const struct _microbit_pin_obj_t microbit_p15_obj;
-extern const struct _microbit_pin_obj_t microbit_p16_obj;
-extern const struct _microbit_pin_obj_t microbit_p19_obj;
-extern const struct _microbit_pin_obj_t microbit_p20_obj;
-
 extern const mp_obj_type_t microbit_const_image_type;
 extern const struct _monochrome_5by5_t microbit_const_image_heart_obj;
 extern const struct _monochrome_5by5_t microbit_const_image_heart_small_obj;

--- a/source/microbit/help.c
+++ b/source/microbit/help.c
@@ -29,6 +29,7 @@
 #include "py/nlr.h"
 #include "py/obj.h"
 #include "microbit/modmicrobit.h"
+#include "microbit/microbitpin.h"
 
 STATIC const char *help_text =
 "Welcome to MicroPython on the micro:bit!\n"

--- a/source/microbit/microbitpin.cpp
+++ b/source/microbit/microbitpin.cpp
@@ -36,27 +36,38 @@ extern "C" {
 #include "nrf_gpio.h"
 #include "py/mphal.h"
 
+const microbit_pin_obj_t microbit_pins[] = {
+    {{&microbit_touch_pin_type}, 0, MICROBIT_PIN_P0, MODE_UNUSED},
+    {{&microbit_touch_pin_type}, 1, MICROBIT_PIN_P1, MODE_UNUSED},
+    {{&microbit_touch_pin_type}, 2, MICROBIT_PIN_P2, MODE_UNUSED},
+    {{&microbit_ad_pin_type},   3,  MICROBIT_PIN_P3, MODE_DISPLAY},
+    {{&microbit_ad_pin_type},   4,  MICROBIT_PIN_P4, MODE_DISPLAY},
+    {{&microbit_dig_pin_type},  5,  MICROBIT_PIN_P5, MODE_BUTTON},
+    {{&microbit_dig_pin_type},  6,  MICROBIT_PIN_P6, MODE_DISPLAY},
+    {{&microbit_dig_pin_type},  7,  MICROBIT_PIN_P7, MODE_DISPLAY},
+    {{&microbit_dig_pin_type},  8,  MICROBIT_PIN_P8, MODE_UNUSED},
+    {{&microbit_dig_pin_type},  9,  MICROBIT_PIN_P9, MODE_DISPLAY},
+    {{&microbit_ad_pin_type},  10, MICROBIT_PIN_P10, MODE_DISPLAY},
+    {{&microbit_dig_pin_type}, 11, MICROBIT_PIN_P11, MODE_BUTTON},
+    {{&microbit_dig_pin_type}, 12, MICROBIT_PIN_P12, MODE_UNUSED},
+    {{&microbit_dig_pin_type}, 13, MICROBIT_PIN_P13, MODE_UNUSED},
+    {{&microbit_dig_pin_type}, 14, MICROBIT_PIN_P14, MODE_UNUSED},
+    {{&microbit_dig_pin_type}, 15, MICROBIT_PIN_P15, MODE_UNUSED},
+    {{&microbit_dig_pin_type}, 16, MICROBIT_PIN_P16, MODE_UNUSED},
+    {{NULL}, 31, 31, 31},
+    {{NULL}, 31, 31, 31},
+    {{&microbit_dig_pin_type}, 19, MICROBIT_PIN_P19, MODE_I2C},
+    {{&microbit_dig_pin_type}, 20, MICROBIT_PIN_P20, MODE_I2C}
+};
 
-const microbit_pin_obj_t microbit_p0_obj = {{&microbit_touch_pin_type}, 0, MICROBIT_PIN_P0, MODE_UNUSED};
-const microbit_pin_obj_t microbit_p1_obj = {{&microbit_touch_pin_type}, 1, MICROBIT_PIN_P1, MODE_UNUSED};
-const microbit_pin_obj_t microbit_p2_obj = {{&microbit_touch_pin_type}, 2, MICROBIT_PIN_P2, MODE_UNUSED};
-const microbit_pin_obj_t microbit_p3_obj = {{&microbit_ad_pin_type},   3,  MICROBIT_PIN_P3, MODE_DISPLAY};
-const microbit_pin_obj_t microbit_p4_obj = {{&microbit_ad_pin_type},   4,  MICROBIT_PIN_P4, MODE_DISPLAY};
-const microbit_pin_obj_t microbit_p5_obj = {{&microbit_dig_pin_type},  5,  MICROBIT_PIN_P5, MODE_BUTTON};
-const microbit_pin_obj_t microbit_p6_obj = {{&microbit_dig_pin_type},  6,  MICROBIT_PIN_P6, MODE_DISPLAY};
-const microbit_pin_obj_t microbit_p7_obj = {{&microbit_dig_pin_type},  7,  MICROBIT_PIN_P7, MODE_DISPLAY};
-const microbit_pin_obj_t microbit_p8_obj = {{&microbit_dig_pin_type},  8,  MICROBIT_PIN_P8, MODE_UNUSED};
-const microbit_pin_obj_t microbit_p9_obj = {{&microbit_dig_pin_type},  9,  MICROBIT_PIN_P9, MODE_DISPLAY};
-const microbit_pin_obj_t microbit_p10_obj = {{&microbit_ad_pin_type},  10, MICROBIT_PIN_P10, MODE_DISPLAY};
-const microbit_pin_obj_t microbit_p11_obj = {{&microbit_dig_pin_type}, 11, MICROBIT_PIN_P11, MODE_BUTTON};
-const microbit_pin_obj_t microbit_p12_obj = {{&microbit_dig_pin_type}, 12, MICROBIT_PIN_P12, MODE_UNUSED};
-const microbit_pin_obj_t microbit_p13_obj = {{&microbit_dig_pin_type}, 13, MICROBIT_PIN_P13, MODE_SPI};
-const microbit_pin_obj_t microbit_p14_obj = {{&microbit_dig_pin_type}, 14, MICROBIT_PIN_P14, MODE_SPI};
-const microbit_pin_obj_t microbit_p15_obj = {{&microbit_dig_pin_type}, 15, MICROBIT_PIN_P15, MODE_SPI};
-const microbit_pin_obj_t microbit_p16_obj = {{&microbit_dig_pin_type}, 16, MICROBIT_PIN_P16, MODE_UNUSED};
-const microbit_pin_obj_t microbit_p19_obj = {{&microbit_dig_pin_type}, 19, MICROBIT_PIN_P19, MODE_I2C};
-const microbit_pin_obj_t microbit_p20_obj = {{&microbit_dig_pin_type}, 20, MICROBIT_PIN_P20, MODE_I2C};
+static const uint32_t VALID_PIN_MASK = (((1<<17)-1) + (1<<19) + (1<<20));
 
+const microbit_pin_obj_t *microbit_pin_from_number(uint32_t number) {
+    if (VALID_PIN_MASK&(1<<number)) {
+        return &microbit_pins[number];
+    }
+    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_RuntimeError, "Non-existent pin %d", number));
+}
 
 static mp_obj_t microbit_pin_get_mode_func(mp_obj_t self_in) {
     microbit_pin_obj_t *self = (microbit_pin_obj_t*)self_in;

--- a/source/microbit/modmicrobit.cpp
+++ b/source/microbit/modmicrobit.cpp
@@ -33,6 +33,7 @@ extern "C" {
 #include "py/mphal.h"
 #include "modmicrobit.h"
 #include "microbitdisplay.h"
+#include "microbit/microbitpin.h"
 #include "microbitimage.h"
 
 extern uint32_t ticks;


### PR DESCRIPTION
Fixes #406 
Also fixes the problem that #397 was meant to address.

**WARNING** this hasn't been tested properly as I don't have the necessary hardware.
I have tested that pins can be used as expected, but I am not able test that the SPI still works correctly.

This PR needs #405 to be merged first (and possibly then rebased), I am putting it up here in case anyone is feels like testing it.


