### PR TITLE
Add additional version info to os.uname().version.

### DIFF
--- a/source/microbit/modos.c
+++ b/source/microbit/modos.c
@@ -29,6 +29,10 @@
 #include "py/objtuple.h"
 #include "py/objstr.h"
 #include "genhdr/mpversion.h"
+#include YOTTA_BUILD_INFO_HEADER
+
+#define _MP_STRINGIFY(x) #x
+#define MP_STRINGIFY(x) _MP_STRINGIFY(x)
 
 #define RELEASE "1.0"
 
@@ -39,7 +43,14 @@ STATIC const qstr os_uname_info_fields[] = {
 STATIC const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_PY_SYS_PLATFORM);
 STATIC const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_PY_SYS_PLATFORM);
 STATIC const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, RELEASE);
-STATIC const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
+STATIC const MP_DEFINE_STR_OBJ(os_uname_info_version_obj,
+    "micro:bit v" RELEASE
+    "-" MP_STRINGIFY(YOTTA_BUILD_VCS_DESCRIPTION)
+    #if YOTTA_BUILD_VCS_CLEAN == 0
+    "-dirty"
+    #endif
+    " on " MP_STRINGIFY(YOTTA_BUILD_YEAR) "-" MP_STRINGIFY(YOTTA_BUILD_MONTH) "-" MP_STRINGIFY(YOTTA_BUILD_DAY)
+    "; MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
 STATIC const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
 
 STATIC MP_DEFINE_ATTRTUPLE(


### PR DESCRIPTION
This additional info can be used to tell the exact git commit from this repository that was used to build the firmware.

Exampe output:
```
MicroPython v1.7-9-gbe020eb on 2016-04-18; micro:bit with nRF51822
Type "help()" for more information.
>>> import os
>>> os.uname().version
"micro:bit v1.0-b'64a61db' (dirty); MicroPython v1.7-9-gbe020eb on 2016-04-18"
>>> 
```

This gives the git hash of this repo, as well as the upstream uPy version.

If one wanted to extract this info from a hex file it would be pretty straightforward: just write a script to scan the .hex file for the string "micro:bit v" and then extract the version info.

See #370 for discussion around this point.