### PR TITLE
Automatically allocate the uPy heap using all the left-over RAM.

### DIFF
--- a/source/microbit/mprun.c
+++ b/source/microbit/mprun.c
@@ -98,21 +98,10 @@ void mp_run(void) {
     mp_stack_ctrl_init();
     mp_stack_set_limit(1800); // stack is 2k
 
-    // allocate the heap statically in the bss
-    static uint32_t heap[9732 / 4];
-    gc_init(heap, (uint8_t*)heap + sizeof(heap));
-
-    /*
-    // allocate the heap using system malloc
-    extern void *malloc(int);
-    void *mheap = malloc(2000);
-    gc_init(mheap, (byte*)mheap + 2000);
-    */
-
-    /*
-    // allocate the heap statically (will clash with BLE)
-    gc_init((void*)0x20000100, (void*)0x20002000);
-    */
+    // allocate the uPy heap statically in the available RAM between heap and stack
+    extern uint32_t __HeapLimit;
+    extern uint32_t __StackLimit;
+    gc_init(&__HeapLimit, &__StackLimit);
 
     mp_init();
     mp_hal_init();


### PR DESCRIPTION
This change removes the fixed-size uPy heap and replaces it with automatic allocation so that the heap is as large as can be, using all the left-over RAM.  The location of the uPy heap is after the mbed 2k heap and before the 2k stack.

This automatic allocation should prevent any build problems when there are small changes in the amount of data/bss being used, or when the code is built with a different version of the compiler, and will ensure that the entire RAM is always used to its full potential.