### PR TITLE
Fix some mistakes in the in-code documentation of neopixel.h

### DIFF
--- a/inc/lib/neopixel.h
+++ b/inc/lib/neopixel.h
@@ -115,10 +115,10 @@ uint8_t neopixel_set_color(neopixel_strip_t *strip, uint16_t index, uint8_t red,
 /**
   @brief Write RGB value to LED structure and update LED
   @param[in] pointer to Strip structure
+  @param[in] LED number (starting at 1)
   @param[in] red value
   @param[in] green value
   @param[in] blue value
-  @param[in] LED number (starting at 1)
   @retval 0 Successful write
   @retval 1 LED number is out of bounds
 */

--- a/inc/lib/neopixel.h
+++ b/inc/lib/neopixel.h
@@ -102,10 +102,10 @@ void neopixel_show(neopixel_strip_t *strip);
 /**
   @brief Write RGB value to LED structure
   @param[in] pointer to Strip structure
+	@param[in] LED number (starting at 1)
 	@param[in] red value
 	@param[in] green value
 	@param[in] blue value
-	@param[in] LED number (starting at 1)
   @retval 0 Successful write
   @retval 1 LED number is out of bounds
 */

--- a/inc/lib/neopixel.h
+++ b/inc/lib/neopixel.h
@@ -102,7 +102,7 @@ void neopixel_show(neopixel_strip_t *strip);
 /**
   @brief Write RGB value to LED structure
   @param[in] pointer to Strip structure
-  @param[in] LED number (starting at 1)
+  @param[in] LED number (starting at 0)
   @param[in] red value
   @param[in] green value
   @param[in] blue value
@@ -115,7 +115,7 @@ uint8_t neopixel_set_color(neopixel_strip_t *strip, uint16_t index, uint8_t red,
 /**
   @brief Write RGB value to LED structure and update LED
   @param[in] pointer to Strip structure
-  @param[in] LED number (starting at 1)
+  @param[in] LED number (starting at 0)
   @param[in] red value
   @param[in] green value
   @param[in] blue value

--- a/inc/lib/neopixel.h
+++ b/inc/lib/neopixel.h
@@ -37,56 +37,56 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 //These defines are timed specific to a series of if statements and will need to be changed
 //to compensate for different writing algorithms than the one in neopixel.c
-#define NEOPIXEL_SEND_ONE	NRF_GPIO->OUTSET = (1UL << PIN); \
-		__ASM ( \
-				" NOP\n\t" \
-				" NOP\n\t" \
-				" NOP\n\t" \
-				" NOP\n\t" \
-				" NOP\n\t" \
-				" NOP\n\t" \
-				" NOP\n\t" \
-				" NOP\n\t" \
-				" NOP\n\t" \
-			); \
-		NRF_GPIO->OUTCLR = (1UL << PIN); \
+#define NEOPIXEL_SEND_ONE NRF_GPIO->OUTSET = (1UL << PIN); \
+    __ASM ( \
+        " NOP\n\t" \
+        " NOP\n\t" \
+        " NOP\n\t" \
+        " NOP\n\t" \
+        " NOP\n\t" \
+        " NOP\n\t" \
+        " NOP\n\t" \
+        " NOP\n\t" \
+        " NOP\n\t" \
+      ); \
+    NRF_GPIO->OUTCLR = (1UL << PIN); \
 
 #define NEOPIXEL_SEND_ZERO NRF_GPIO->OUTSET = (1UL << PIN); \
-		__ASM (  \
-				" NOP\n\t"  \
-			);  \
-		NRF_GPIO->OUTCLR = (1UL << PIN);  \
-		__ASM ( \
-				" NOP\n\t" \
-				" NOP\n\t" \
-				" NOP\n\t" \
-				" NOP\n\t" \
-				" NOP\n\t" \
-				" NOP\n\t" \
-				" NOP\n\t" \
-				" NOP\n\t" \
-			);
-		
+    __ASM (  \
+        " NOP\n\t"  \
+      );  \
+    NRF_GPIO->OUTCLR = (1UL << PIN);  \
+    __ASM ( \
+        " NOP\n\t" \
+        " NOP\n\t" \
+        " NOP\n\t" \
+        " NOP\n\t" \
+        " NOP\n\t" \
+        " NOP\n\t" \
+        " NOP\n\t" \
+        " NOP\n\t" \
+      );
+
 typedef union {
-		struct {
-			uint8_t g, r, b;
-		}simple;
-    uint8_t grb[3];
+  struct {
+    uint8_t g, r, b;
+  }simple;
+  uint8_t grb[3];
 } color_t;
 
 typedef struct _neopixel_strip_t {
-	uint8_t pin_num;
-	uint16_t num_leds;
-	color_t *leds;
+  uint8_t pin_num;
+  uint16_t num_leds;
+  color_t *leds;
 } neopixel_strip_t;
 
 /**
   @brief Initialize GPIO and data location
   @param[in] pointer to Strip structure
-	@param[in] pin number for GPIO
+  @param[in] pin number for GPIO
 */
 void neopixel_init(neopixel_strip_t *strip, uint8_t pin_num, uint16_t num_leds);
-	
+
 /**
   @brief Turn all LEDs off
   @param[in] pointer to Strip structure
@@ -102,10 +102,10 @@ void neopixel_show(neopixel_strip_t *strip);
 /**
   @brief Write RGB value to LED structure
   @param[in] pointer to Strip structure
-	@param[in] LED number (starting at 1)
-	@param[in] red value
-	@param[in] green value
-	@param[in] blue value
+  @param[in] LED number (starting at 1)
+  @param[in] red value
+  @param[in] green value
+  @param[in] blue value
   @retval 0 Successful write
   @retval 1 LED number is out of bounds
 */
@@ -115,10 +115,10 @@ uint8_t neopixel_set_color(neopixel_strip_t *strip, uint16_t index, uint8_t red,
 /**
   @brief Write RGB value to LED structure and update LED
   @param[in] pointer to Strip structure
-	@param[in] red value
-	@param[in] green value
-	@param[in] blue value
-	@param[in] LED number (starting at 1)
+  @param[in] red value
+  @param[in] green value
+  @param[in] blue value
+  @param[in] LED number (starting at 1)
   @retval 0 Successful write
   @retval 1 LED number is out of bounds
 */


### PR DESCRIPTION
Item order was wrong and indices were falsely claimed to start with index 1 (start with 0).