### PR TITLE
Update documentation for PWM period minimum microseconds value

### DIFF
--- a/docs/pin.rst
+++ b/docs/pin.rst
@@ -162,7 +162,7 @@ its own to that.
     .. py:method:: set_analog_period_microseconds(period)
 
         Set the period of the PWM signal being output to ``period`` in
-        microseconds. The minimum valid value is 35µs.
+        microseconds. The minimum valid value is 256µs.
 
 
 .. py:class:: MicroBitTouchPin


### PR DESCRIPTION
Noticed the documentation wasn't correct, so just a very quick edit to fix that.
Link to the source code clamp value: [source/lib/pwm.c#L181](https://github.com/bbcmicrobit/micropython/blob/9cef1292df38649ad7f11e0c4b8c27bbacda6c3d/source/lib/pwm.c#L181)