### PR TITLE
Allow floats and integers in display.show and arbitrary objects in display.scroll

### DIFF
--- a/docs/display.rst
+++ b/docs/display.rst
@@ -32,10 +32,11 @@ Functions
     Display the ``image``.
 
 
-.. py:function:: show(iterable, delay=400, \*, wait=True, loop=False, clear=False)
+.. py:function:: show(value, delay=400, \*, wait=True, loop=False, clear=False)
 
-    Display images or letters from the ``iterable`` in sequence, with ``delay``
-    milliseconds between them.
+    If ``value`` is a string, float or integer, display letters/digits in sequence.
+    Otherwise, if ``value`` is an iterable sequence of images, display these images in sequence.
+    Each letter, digit or image is shown with ``delay`` milliseconds between them.
 
     If ``wait`` is ``True``, this function will block until the animation is
     finished, otherwise the animation will happen in the background.
@@ -53,10 +54,11 @@ Functions
     in the generator as allocating memory in an interrupt is prohibited and will raise a
     ``MemoryError``.
 
-.. py:function:: scroll(string, delay=150, \*, wait=True, loop=False, monospace=False)
+.. py:function:: scroll(value, delay=150, \*, wait=True, loop=False, monospace=False)
 
-    Similar to ``show``, but scrolls the ``string`` horizontally instead. The
-    ``delay`` parameter controls how fast the text is scrolling.
+    Scrolls ``value`` horizontally on the display. If ``value`` is not a string, it is
+    first converted to a string using ``str()``. The ``delay`` parameter controls how fast
+    the text is scrolling.
 
     If ``wait`` is ``True``, this function will block until the animation is
     finished, otherwise the animation will happen in the background.

--- a/source/microbit/microbitdisplay.cpp
+++ b/source/microbit/microbitdisplay.cpp
@@ -31,6 +31,7 @@ extern "C" {
 
 #include "py/runtime.h"
 #include "py/gc.h"
+#include "py/objstr.h"
 #include "lib/iters.h"
 #include "lib/ticker.h"
 #include "microbit/modmicrobit.h"
@@ -432,7 +433,13 @@ mp_obj_t microbit_display_scroll_func(mp_uint_t n_args, const mp_obj_t *pos_args
     mp_arg_val_t args[MP_ARRAY_SIZE(scroll_allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(scroll_allowed_args), scroll_allowed_args, args);
     mp_uint_t len;
-    const char* str = mp_obj_str_get_data(args[0].u_obj, &len);
+    mp_obj_t object_string;
+    if (!MP_OBJ_IS_TYPE(args[0].u_obj, &mp_type_str)) {
+        object_string = mp_obj_str_make_new(&mp_type_str, 1, 0, &args[0].u_obj);
+    } else {
+        object_string = args[0].u_obj;
+    }
+    const char* str = mp_obj_str_get_data(object_string, &len);
     mp_obj_t iterable = scrolling_string_image_iterable(str, len, args[0].u_obj, args[3].u_bool /*monospace?*/, args[4].u_bool /*loop*/);
     microbit_display_animate(self, iterable, args[1].u_int /*delay*/, false/*clear*/, args[2].u_bool/*wait?*/);
     return mp_const_none;

--- a/source/microbit/microbitdisplay.cpp
+++ b/source/microbit/microbitdisplay.cpp
@@ -110,6 +110,11 @@ mp_obj_t microbit_display_show_func(mp_uint_t n_args, const mp_obj_t *pos_args, 
     bool wait = args[3].u_bool;
     bool loop = args[4].u_bool;
 
+    // Convert to string from an integer or float if applicable
+    if (MP_OBJ_IS_INT(image) || mp_obj_is_float(image)) {
+        image = mp_obj_str_make_new(&mp_type_str, 1, 0, &image);
+    }
+
     if (MP_OBJ_IS_STR(image)) {
         // arg is a string object
         mp_uint_t len;
@@ -131,6 +136,7 @@ mp_obj_t microbit_display_show_func(mp_uint_t n_args, const mp_obj_t *pos_args, 
         }
         image = mp_obj_new_tuple(1, &image);
     }
+
     // iterable:
     if (args[4].u_bool) { /*loop*/
         image = microbit_repeat_iterator(image);


### PR DESCRIPTION
This is implemented in display.scroll and display.show by calling the `mp_obj_str_make_new` function on the objects which aren't normally accepted.