### PR TITLE
Add "active" to increase specificity

### DIFF
--- a/docs/tutorials/io.rst
+++ b/docs/tutorials/io.rst
@@ -45,7 +45,7 @@ when you plug in circuits and other devices via the pins.
 Bleeps and Bloops
 +++++++++++++++++
 
-The simplest thing we can attach to the device is a Piezo buzzer. We're going
+The simplest thing we can attach to the device is an active Piezo buzzer. We're going
 to use it for output.
 
 .. image:: piezo_buzzer.jpg


### PR DESCRIPTION
There are active piezo buzzers that include their own oscillator to produce a tone of a predetermined frequency when a current is applied and passive piezo buzzers that require an oscillating current to produce a tone, that tone being of the frequency at which the current alternates.  This section and the next fail to recognize that difference.  A passive buzzer used in these exercises would at best produce a click when a current was switched on or off.
I suppose one could potentially chalk it up to an issue of semantics, as some might call an active buzzer a buzzer and a passive buzzer a speaker, but I think it is fairly common to refer to a low fidelity piezo as a buzzer.