### PR TITLE
Added note about ufs get and put

### DIFF
--- a/docs/tutorials/storage.rst
+++ b/docs/tutorials/storage.rst
@@ -210,6 +210,9 @@ Finally, the ``put`` sub-command puts a file from your computer onto the
 connected device (it's named after the ``put`` command that's part of FTP that
 serves the same function).
 
+.. note::
+    The ufs get and put commands only operate on one file at a time.
+
 Mainly main.py
 ++++++++++++++
 


### PR DESCRIPTION
I was scratching my head for a while trying to figure out why the next example utilizing hello.py and main.py wasn't working until I realized that "ufs put hello.py main.py" was only copying hello.py but saving it as main.py on the remote filesystem.  This note will hopefully help others avoid such confusion.