### PR TITLE
Change the order of precedence for user code execution

### DIFF
--- a/source/microbit/main.cpp
+++ b/source/microbit/main.cpp
@@ -166,11 +166,11 @@ int main(void) {
         // mode.  If we are in "raw REPL" mode then this will be skipped.
         if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
             file_descriptor_obj *main_module;
-            if (APPENDED_SCRIPT->header[0] == 'M' && APPENDED_SCRIPT->header[1] == 'P') {
+            if (main_module = microbit_file_open("main.py", 7, false, false)) {
+                do_file(main_module);
+            } else if (APPENDED_SCRIPT->header[0] == 'M' && APPENDED_SCRIPT->header[1] == 'P') {
                 // run appended script
                 do_strn(APPENDED_SCRIPT->str, APPENDED_SCRIPT->len);
-            } else if ((main_module = microbit_file_open("main.py", 7, false, false))) {
-                do_file(main_module);
             } else {
                 // from microbit import *
                 mp_import_all(mp_import_name(MP_QSTR_microbit, mp_const_empty_tuple, MP_OBJ_NEW_SMALL_INT(0)));

--- a/source/microbit/main.cpp
+++ b/source/microbit/main.cpp
@@ -166,7 +166,7 @@ int main(void) {
         // mode.  If we are in "raw REPL" mode then this will be skipped.
         if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
             file_descriptor_obj *main_module;
-            if (main_module = microbit_file_open("main.py", 7, false, false)) {
+            if ((main_module = microbit_file_open("main.py", 7, false, false))) {
                 do_file(main_module);
             } else if (APPENDED_SCRIPT->header[0] == 'M' && APPENDED_SCRIPT->header[1] == 'P') {
                 // run appended script


### PR DESCRIPTION
Proposed change from https://github.com/bbcmicrobit/micropython/issues/525.

The old behaviour prioritises code embedded in the known flash location over a main.py file in the file system. This change reverses that order.