### PR TITLE
Add micro:bit release string to REPL banner

### DIFF
--- a/inc/microbit/mpconfigport.h
+++ b/inc/microbit/mpconfigport.h
@@ -164,7 +164,7 @@ void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len);
 
 #define MICROBIT_RELEASE "1.0.0-beta.1"
 #define MICROBIT_BOARD_NAME "micro:bit"
-#define MICROPY_HW_BOARD_NAME MICROBIT_BOARD_NAME " " MICROBIT_RELEASE
+#define MICROPY_HW_BOARD_NAME MICROBIT_BOARD_NAME " v" MICROBIT_RELEASE
 #define MICROPY_HW_MCU_NAME "nRF51822"
 
 // Toolchain seems to be missing M_PI

--- a/inc/microbit/mpconfigport.h
+++ b/inc/microbit/mpconfigport.h
@@ -163,7 +163,8 @@ void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len);
 #include <alloca.h>
 
 #define MICROBIT_RELEASE "1.0.0-beta.1"
-#define MICROPY_HW_BOARD_NAME "micro:bit"
+#define MICROBIT_BOARD_NAME "micro:bit"
+#define MICROPY_HW_BOARD_NAME MICROBIT_BOARD_NAME " " MICROBIT_RELEASE
 #define MICROPY_HW_MCU_NAME "nRF51822"
 
 // Toolchain seems to be missing M_PI

--- a/inc/microbit/mpconfigport.h
+++ b/inc/microbit/mpconfigport.h
@@ -162,6 +162,7 @@ void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len);
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>
 
+#define MICROBIT_RELEASE "1.0.0-beta.1"
 #define MICROPY_HW_BOARD_NAME "micro:bit"
 #define MICROPY_HW_MCU_NAME "nRF51822"
 

--- a/source/microbit/modos.c
+++ b/source/microbit/modos.c
@@ -31,14 +31,12 @@
 #include "genhdr/mpversion.h"
 #include "genhdr/microbitversion.h"
 
-#define RELEASE "1.0.0-beta.1"
-
-#define VERSION \
-    "micro:bit " RELEASE "+" MICROBIT_GIT_HASH " on " MICROBIT_BUILD_DATE \
+#define MICROBIT_VERSION \
+    "micro:bit " MICROBIT_RELEASE "+" MICROBIT_GIT_HASH " on " MICROBIT_BUILD_DATE \
     "; MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE
 
-const char microbit_release_string[] = RELEASE;
-const char microbit_version_string[] = VERSION;
+const char microbit_release_string[] = MICROBIT_RELEASE;
+const char microbit_version_string[] = MICROBIT_VERSION;
 
 STATIC const qstr os_uname_info_fields[] = {
     MP_QSTR_sysname, MP_QSTR_nodename,

--- a/source/microbit/modos.c
+++ b/source/microbit/modos.c
@@ -46,7 +46,7 @@ STATIC const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_PY_SYS_PLATFOR
 STATIC const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_PY_SYS_PLATFORM);
 STATIC const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, microbit_release_string);
 STATIC const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, microbit_version_string);
-STATIC const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
+STATIC const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROBIT_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
 
 STATIC MP_DEFINE_ATTRTUPLE(
     os_uname_info_obj,

--- a/source/microbit/modos.c
+++ b/source/microbit/modos.c
@@ -32,7 +32,7 @@
 #include "genhdr/microbitversion.h"
 
 #define MICROBIT_VERSION \
-    "micro:bit " MICROBIT_RELEASE "+" MICROBIT_GIT_HASH " on " MICROBIT_BUILD_DATE \
+    "micro:bit v" MICROBIT_RELEASE "+" MICROBIT_GIT_HASH " on " MICROBIT_BUILD_DATE \
     "; MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE
 
 const char microbit_release_string[] = MICROBIT_RELEASE;


### PR DESCRIPTION
The REPL banner now looks something like this:

    MicroPython v1.9.2-34-gd64154c73 on 2017-09-01; micro:bit 1.0.0-beta.1 with nRF51822
    Type "help()" for more information.
    >>>

The output of os.uname() in unchanged.

