### PR TITLE
Allow to change pin in touch mode to other mode without error.

### DIFF
--- a/source/microbit/microbitpinmode.c
+++ b/source/microbit/microbitpinmode.c
@@ -97,7 +97,7 @@ const microbit_pinmode_t microbit_pinmodes[] = {
     [MODE_BUTTON]        = { MP_QSTR_button, pinmode_error },
     [MODE_MUSIC]         = { MP_QSTR_music, pinmode_error },
     [MODE_AUDIO_PLAY]    = { MP_QSTR_audio, noop },
-    [MODE_TOUCH]         = { MP_QSTR_touch, pinmode_error },
+    [MODE_TOUCH]         = { MP_QSTR_touch, noop },
     [MODE_I2C]           = { MP_QSTR_i2c, pinmode_error },
     [MODE_SPI]           = { MP_QSTR_spi, pinmode_error }
 };


### PR DESCRIPTION
Since touch mode is pretty much just digital input, it makes sense to be able to change from touch mode to other standard GPIO modes (read digital, write digital, read analog) without an error (you can already change from read digital to write digital without error).

Without a patch like this there's no way to get a pin out of touch mode once `pin.is_touched()` is called.