### PR TITLE
Tune parser memory usage

### DIFF
--- a/inc/microbit/mpconfigport.h
+++ b/inc/microbit/mpconfigport.h
@@ -33,6 +33,8 @@
 
 // memory allocation policies
 #define MICROPY_ALLOC_GC_STACK_SIZE (32)
+#define MICROPY_ALLOC_PARSE_RULE_INIT (96)
+#define MICROPY_ALLOC_PARSE_RULE_INC (24)
 #define MICROPY_ALLOC_PATH_MAX      (64)
 #define MICROPY_QSTR_BYTES_IN_HASH  (1)
 

--- a/source/py/parse2.c
+++ b/source/py/parse2.c
@@ -132,8 +132,8 @@ STATIC const rule_t *rules[] = {
 typedef struct _rule_stack_t {
     size_t src_line : 8 * sizeof(size_t) - 8; // maximum bits storing source line number
     size_t rule_id : 8; // this must be large enough to fit largest rule number
-    size_t arg_i; // this dictates the maximum nodes in a "list" of things
-    size_t pt_off;
+    size_t arg_i : 16; // this dictates the maximum nodes in a "list" of things
+    size_t pt_off : 16;
 } rule_stack_t;
 
 typedef struct _mp_parse_chunk_t {


### PR DESCRIPTION
There are 2 commits here:

### first commit

py/parse2: Make rule_stack_t take only 8 bytes per entry, not 12.

Takes less memory when parsing.  Restrictions introduced by this change
are:
- maximum parse tree size is 65535 bytes (was 4G)
- maximum number of expressions in a tuple, list, dict, etc is 65535
  (was 4G)

Given the amount of memory on the device is so small, these new limits
should never be reached.

### second commit

microbit: Tune parser memory allocation policy.

Combined with the previous change to rule_stack_t, this makes sure that
the number of bytes allocated for the parser's rule stack is unchanged for
the initial allocation, and for subsequent resizes of the stack.

What does change is that now the rules stack can hold more entries for the
same number of bytes.  The result is that there will be less resizes of the
rule stack.

### summary

This should make the memory allocation patterns of code running under the latest version similar to v0.9 (before updating to upstream MicroPython 1.9.2).

This should be a relatively low risk change, but would still need some testing.
