### PR TITLE
microbit: Allow pins in button mode to work as a digital-in pin would.

### DIFF
--- a/source/microbit/microbitpin.cpp
+++ b/source/microbit/microbitpin.cpp
@@ -108,8 +108,8 @@ MP_DEFINE_CONST_FUN_OBJ_2(microbit_pin_set_pull_obj, microbit_pin_set_pull);
 mp_obj_t microbit_pin_get_pull(mp_obj_t self_in) {
     microbit_pin_obj_t *self = (microbit_pin_obj_t*)self_in;
     const microbit_pinmode_t *mode = microbit_pin_get_mode(self);
-    /* Pull only applies in an read digital mode */
-    if (mode != microbit_pin_mode_read_digital) {
+    /* Pull only applies in an read digital mode (and button mode behaves like that too) */
+    if (mode != microbit_pin_mode_read_digital && mode != microbit_pin_mode_button) {
         pinmode_error(self);
     }
     uint32_t pull = (NRF_GPIO->PIN_CNF[self->name] >> GPIO_PIN_CNF_PULL_Pos) & PULL_MASK;

--- a/source/microbit/microbitpinmode.c
+++ b/source/microbit/microbitpinmode.c
@@ -66,6 +66,12 @@ bool microbit_obj_pin_can_be_acquired(const microbit_pin_obj_t *pin) {
 
 bool microbit_obj_pin_acquire(const microbit_pin_obj_t *pin, const microbit_pinmode_t *new_mode) {
     const microbit_pinmode_t *current_mode = microbit_pin_get_mode(pin);
+
+    // The button mode is effectively a digital-in mode, so allow read_digital to work on a button
+    if (current_mode == microbit_pin_mode_button && new_mode == microbit_pin_mode_read_digital) {
+        return false;
+    }
+
     if (current_mode != new_mode) {
         current_mode->release(pin);
         set_mode(pin->number, new_mode);


### PR DESCRIPTION
So that read_digital(), set_pull() and get_pull() work on pin5 and pin11.

See issue #556