### PR TITLE
docs: Update repl.rst to include more information on serial communication

### DIFF
--- a/docs/devguide/repl.rst
+++ b/docs/devguide/repl.rst
@@ -4,42 +4,71 @@
 Accessing the REPL
 ==================
 
-Accessing the REPL on the micro:bit requires:
+REPL (Read-Evaluate-Print-Loop) allows the micro:bit to read and evaluate code in real-time as you write it.
 
-    * Using a serial communication program
-    * Determining the communication port identifier for the micro:bit
-    * Establishing communication with the correct settings for your computer
+Accessing the REPL on the micro:bit will require you to:
 
-If you are a Windows user you'll need to install the correct drivers. The
+    * Determine the communication port identifier for the micro:bit
+    * Use a program to establish communication with the correct settings for your computer
+
+If you are a Windows user you'll need to install the correct drivers, the
 instructions for which are found here:
 
 https://developer.mbed.org/handbook/Windows-serial-configuration
 
-Serial communication
+
+Using a serial communication program
+------------------------------------
+
+The `Mu Editor <https://codewith.mu/en/tutorials/1.0/repl>`_ has built-in support for REPL and even includes a real-time data plotter. Some other common options are `picocom` and `screen`. You will need to install a program and read the appropriate documentation to understand the basics of connecting to a device.
+
+
+Determining the port
 --------------------
 
-To access the REPL, you need to select a program to use for serial communication.
-Some common options are `picocom` and `screen`. You will need to install
-program and understand the basics of connecting to a device.
+The micro:bit will have a port identifier (tty, usb) that can be used by the computer for communicating. Before connecting to the micro:bit we must determine the port identifier.
 
-Determining port
-----------------
+**Windows**
 
-The micro:bit will have a port identifier (tty, usb) that can be used by the computer for
-communicating. Before connecting to the micro:bit, we must determine the port identifier.
+When you have installed the aforementioned drivers the micro:bit will appear in device-manager as a COM port.
 
-Establishing communication with the micro:bit
----------------------------------------------
+**Mac OS**
 
-Depending on your operating system, environment, and serial communication program,
-the settings and commands will vary a bit. Here are some common settings for different
-systems (please suggest additions that might help others)
+Open Terminal and type ``ls /dev/cu.*`` to see a list of connected serial devices; one of them will look like ``/dev/cu.usbmodem1422`` (the exact number will depend on your computer).
 
-**Settings**
+**Linux**
 
-* :ref:`Windows <microbit-windows>`
-* :ref:`OS X <microbit-osx>`
-* :ref:`Linux <microbit-linux>`
-* :ref:`Debian and Ubuntu <microbit-debian-ubuntu>`
-* :ref:`Red Hat Fedora/CentOS <microbit-redhat>`
-* :ref:`Raspberry Pi <microbit-rpi>`
+In terminal, type ``dmesg | tail`` which will show which ``/dev`` node the micro:bit was assigned (e.g. ``/dev/ttyUSB0``).
+
+
+Communicating with the micro:bit
+--------------------------------
+
+Once you have found the port identifier you can use a program to communicate with the micro:bit.
+
+**Windows**
+
+You may wish to use Tera Term, PuTTY, or another program.
+
+In Tera Term:
+	* Plug in the micro:bit and open Tera Term
+	* Select Serial as the port
+	* Go to Setup -> Serial port. Ensure the Port is the correct COM port, choose a baud rate of ``115200``, data 8 bits, parity none, stop 1 bit
+
+In PuTTY:
+	* Plug in the micro:bit and open PuTTY
+	* Switch the Connection Type to Serial and ensure the Port is the correct COM port
+	* Change the baud rate to ``115200``
+	* Select 'Serial' on the menu on the left, then click 'Open'
+
+
+**Mac OS**
+
+Open Terminal and type ``screen /dev/cu.usbmodem1422 115200``, replacing ``/dev/cu.usbmodem1422`` with the port you found earlier. This will open the micro:bit's serial output and show all messages received from the device. To exit, press Ctrl-A then Ctrl-D.
+
+
+**Linux**
+
+Using the ``screen`` program, type ``screen /dev/ttyUSB0 115200``, replacing ``/dev/ttyUSB0`` with the port you found earlier.
+
+Using ``picocom``, type ``picocom /dev/ttyACM0 -b 115200``, again replacing ``/dev/ttyACM0`` with the port you found earlier. 

--- a/docs/devguide/repl.rst
+++ b/docs/devguide/repl.rst
@@ -9,13 +9,13 @@ in real-time as you write it.
 
 Accessing the REPL on the micro:bit will require you to:
 
-    * Determine the communication port identifier for the micro:bit
-    * Use a program to establish communication with the device
+* Determine the communication port identifier for the micro:bit
+* Use a program to establish communication with the device
 
-If you are a Windows user you'll need to install the correct drivers, the
-instructions for which are found here:
+For versions of Windows before 10 you might need to install the Mbed serial 
+driver, the instructions for which are found here:
 
-https://developer.mbed.org/handbook/Windows-serial-configuration
+https://os.mbed.com/docs/latest/tutorials/windows-serial-driver.html
 
 
 Using a serial communication program
@@ -55,8 +55,8 @@ micro:bit was assigned (e.g. ``/dev/ttyUSB0``).
 Communicating with the micro:bit
 --------------------------------
 
-Once you have found the port identifier you can use a program to communicate 
-with the micro:bit.
+Once you have found the port identifier you can use a serial terminal program 
+to communicate with the micro:bit.
 
 **Windows**
 

--- a/docs/devguide/repl.rst
+++ b/docs/devguide/repl.rst
@@ -4,12 +4,13 @@
 Accessing the REPL
 ==================
 
-REPL (Read-Evaluate-Print-Loop) allows the micro:bit to read and evaluate code in real-time as you write it.
+REPL (Read-Evaluate-Print-Loop) allows the micro:bit to read and evaluate code 
+in real-time as you write it.
 
 Accessing the REPL on the micro:bit will require you to:
 
     * Determine the communication port identifier for the micro:bit
-    * Use a program to establish communication with the correct settings for your computer
+    * Use a program to establish communication with the device
 
 If you are a Windows user you'll need to install the correct drivers, the
 instructions for which are found here:
@@ -20,31 +21,42 @@ https://developer.mbed.org/handbook/Windows-serial-configuration
 Using a serial communication program
 ------------------------------------
 
-The `Mu Editor <https://codewith.mu/en/tutorials/1.0/repl>`_ has built-in support for REPL and even includes a real-time data plotter. Some other common options are `picocom` and `screen`. You will need to install a program and read the appropriate documentation to understand the basics of connecting to a device.
+The `Mu Editor <https://codewith.mu/en/tutorials/1.0/repl>`_ has built-in 
+support for REPL and even includes a real-time data plotter. Some other common 
+options are `picocom` and `screen`. You will need to install a program and 
+read the appropriate documentation to understand the basics of connecting to a 
+device.
 
 
 Determining the port
 --------------------
 
-The micro:bit will have a port identifier (tty, usb) that can be used by the computer for communicating. Before connecting to the micro:bit we must determine the port identifier.
+The micro:bit will have a port identifier (tty, usb) that can be used by the 
+computer for communicating. Before connecting to the micro:bit we must 
+determine the port identifier.
 
 **Windows**
 
-When you have installed the aforementioned drivers the micro:bit will appear in device-manager as a COM port.
+When you have installed the aforementioned drivers the micro:bit will appear in
+device-manager as a COM port.
 
 **Mac OS**
 
-Open Terminal and type ``ls /dev/cu.*`` to see a list of connected serial devices; one of them will look like ``/dev/cu.usbmodem1422`` (the exact number will depend on your computer).
+Open Terminal and type ``ls /dev/cu.*`` to see a list of connected serial 
+devices; one of them will look like ``/dev/cu.usbmodem1422`` (the exact number 
+will depend on your computer).
 
 **Linux**
 
-In terminal, type ``dmesg | tail`` which will show which ``/dev`` node the micro:bit was assigned (e.g. ``/dev/ttyUSB0``).
+In terminal, type ``dmesg | tail`` which will show which ``/dev`` node the 
+micro:bit was assigned (e.g. ``/dev/ttyUSB0``).
 
 
 Communicating with the micro:bit
 --------------------------------
 
-Once you have found the port identifier you can use a program to communicate with the micro:bit.
+Once you have found the port identifier you can use a program to communicate 
+with the micro:bit.
 
 **Windows**
 
@@ -53,22 +65,29 @@ You may wish to use Tera Term, PuTTY, or another program.
 In Tera Term:
 	* Plug in the micro:bit and open Tera Term
 	* Select Serial as the port
-	* Go to Setup -> Serial port. Ensure the Port is the correct COM port, choose a baud rate of ``115200``, data 8 bits, parity none, stop 1 bit
+	* Go to Setup -> Serial port. Ensure the Port is the correct COM port.
+	* Choose a baud rate of ``115200``, data 8 bits, parity none, stop 1 bit.
 
 In PuTTY:
 	* Plug in the micro:bit and open PuTTY
-	* Switch the Connection Type to Serial and ensure the Port is the correct COM port
+	* Switch the Connection Type to Serial
+	* Ensure the Port is the correct COM port
 	* Change the baud rate to ``115200``
 	* Select 'Serial' on the menu on the left, then click 'Open'
 
 
 **Mac OS**
 
-Open Terminal and type ``screen /dev/cu.usbmodem1422 115200``, replacing ``/dev/cu.usbmodem1422`` with the port you found earlier. This will open the micro:bit's serial output and show all messages received from the device. To exit, press Ctrl-A then Ctrl-D.
+Open Terminal and type ``screen /dev/cu.usbmodem1422 115200``, replacing 
+``/dev/cu.usbmodem1422`` with the port you found earlier. This will open the 
+micro:bit's serial output and show all messages received from the device. To 
+exit, press Ctrl-A then Ctrl-D.
 
 
 **Linux**
 
-Using the ``screen`` program, type ``screen /dev/ttyUSB0 115200``, replacing ``/dev/ttyUSB0`` with the port you found earlier.
+Using the ``screen`` program, type ``screen /dev/ttyUSB0 115200``, replacing 
+``/dev/ttyUSB0`` with the port you found earlier.
 
-Using ``picocom``, type ``picocom /dev/ttyACM0 -b 115200``, again replacing ``/dev/ttyACM0`` with the port you found earlier. 
+Using ``picocom``, type ``picocom /dev/ttyACM0 -b 115200``, again replacing 
+``/dev/ttyACM0`` with the port you found earlier. 


### PR DESCRIPTION
From #515, update repl.rst in docs with clearer info.

Update REPL guide to restructure page and include:
- information on Mu
- explanation on how to determine micro:bit port in Windows, Mac OS, Linux
- examples for communicating with the micro:bit using serial for Windows, Mac OS, Linux