### PR TITLE
docs: Update uart.rst to include note on internal buffer size

### DIFF
--- a/docs/uart.rst
+++ b/docs/uart.rst
@@ -7,7 +7,8 @@ The ``uart`` module lets you talk to a device connected to your board using
 a serial interface.
 
 .. note::
-    The internal uart buffer is hard coded to 64 bytes.
+    The internal UART RX buffer is 64 bytes, so make sure data is read before 
+    the buffer is full or some of the data might be lost.
 
 Functions
 =========

--- a/docs/uart.rst
+++ b/docs/uart.rst
@@ -6,6 +6,8 @@ UART
 The ``uart`` module lets you talk to a device connected to your board using
 a serial interface.
 
+.. note::
+    The internal uart buffer is hard coded to 64 bytes.
 
 Functions
 =========


### PR DESCRIPTION
Add note on internal uart buffer size to docs; closes #503