### PR TITLE
Update index.rst to include link to audio module

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,6 +61,7 @@ Projects related to MicroPython on the BBC micro:bit include:
    microbit_micropython_api.rst
    microbit.rst
    accelerometer.rst
+   audio.rst
    ble.rst
    button.rst
    compass.rst


### PR DESCRIPTION
Add audio module page to Index -> API reference so it appears in Contents bar.

Closes #414 