### PR TITLE
microbit: Allocate all DAL objects on the DAL heap, to save BSS.

### DIFF
--- a/inc/microbit/microbitdal.h
+++ b/inc/microbit/microbitdal.h
@@ -44,9 +44,9 @@ class MicroPythonI2C : public MicroBitI2C {
         }
 };
 
-extern MicroPythonI2C ubit_i2c;
+extern MicroPythonI2C *ubit_i2c;
 extern MicroBitAccelerometer *ubit_accelerometer;
-extern MicroBitDisplay ubit_display;
+extern MicroBitDisplay *ubit_display;
 extern MicroBitCompass *ubit_compass;
 extern MicroBitCompassCalibrator *ubit_compass_calibrator;
 

--- a/source/microbit/microbitcompass.cpp
+++ b/source/microbit/microbitcompass.cpp
@@ -64,9 +64,9 @@ mp_obj_t microbit_compass_calibrate(mp_obj_t self_in) {
     (void)self_in;
     ticker_stop();
     //uBit.systemTicker.attach_us(&uBit, &MicroBit::systemTick, MICROBIT_DEFAULT_TICK_PERIOD * 1000); TODO what to replace with?
-    ubit_display.enable();
+    ubit_display->enable();
     ubit_compass->calibrate();
-    ubit_display.disable();
+    ubit_display->disable();
     //uBit.systemTicker.detach(); TODO what to replace with?
     ticker_start();
     microbit_display_init();

--- a/source/microbit/microbiti2c.cpp
+++ b/source/microbit/microbiti2c.cpp
@@ -176,7 +176,7 @@ const mp_obj_type_t microbit_i2c_type = {
 
 const microbit_i2c_obj_t microbit_i2c_obj = {
     {&microbit_i2c_type},
-    .i2c = &ubit_i2c,
+    .i2c = ubit_i2c,
 };
 
 }


### PR DESCRIPTION
Then the MicroPython heap can be increased by 128 bytes.