### PR TITLE
docs: Fix audio.play() pin arguments

### DIFF
--- a/docs/audio.rst
+++ b/docs/audio.rst
@@ -14,7 +14,7 @@ which means that it can reproduce frequencies up to 3.9kHz.
 Functions
 =========
 
-.. py:function:: play(source, wait=True, pins=(pin0, pin1))
+.. py:function:: play(source, wait=True, pin=pin0, return_pin=None)
 
     Play the source to completion.
 
@@ -22,7 +22,10 @@ Functions
 
     If ``wait`` is ``True``, this function will block until the source is exhausted.
 
-    ``pins`` specifies which pins the speaker is connected to.
+    ``pin`` specifies which pin the speaker is connected to.
+
+    ``return_pin`` specifies a differential pin to connect to the speaker
+    instead of ground.
 
 Classes
 =======


### PR DESCRIPTION
Fixes https://github.com/bbcmicrobit/micropython/issues/415.

Arguments can be seen in:
https://github.com/bbcmicrobit/micropython/blob/e411337cfe1edf6f86ee70709e81c49a157301fb/source/microbit/modaudio.cpp#L447-L452