### PR TITLE
docs: Add accelerometer range and units

### DIFF
--- a/docs/accelerometer.rst
+++ b/docs/accelerometer.rst
@@ -8,6 +8,9 @@ also provides convenience functions for detecting gestures. The
 recognised gestures are: ``up``, ``down``, ``left``, ``right``, ``face up``,
 ``face down``, ``freefall``, ``3g``, ``6g``, ``8g``, ``shake``.
 
+By default MicroPython sets the accelerometer to +/- 2g, and this can only be
+modified in the DAL layer below. The accelerometer returns a value in the range 
+0..1024 for each axis, which is then scaled accordingly.
 
 Functions
 =========
@@ -15,25 +18,26 @@ Functions
 .. py:function:: get_x()
 
     Get the acceleration measurement in the ``x`` axis, as a positive or
-    negative integer, depending on the direction. 
-    The measurement is given in milli-Newtons, for example +/- 2g will return +/- 2000mN. 
+    negative integer, depending on the direction. The measurement is given in 
+    milli-g, for example +/- 2g will return +/- 2000mg. 
 
 .. py:function:: get_y()
 
     Get the acceleration measurement in the ``y`` axis, as a positive or
-    negative integer, depending on the direction.
-    The measurement is given in milli-Newtons, for example +/- 2g will return +/- 2000mN. 
+    negative integer, depending on the direction.  The measurement is given in
+    milli-g, for example +/- 2g will return +/- 2000mg. 
 
 .. py:function:: get_z()
 
     Get the acceleration measurement in the ``z`` axis, as a positive or
-    negative integer, depending on the direction.
-    The measurement is given in milli-Newtons, for example +/- 2g will return +/- 2000mN. 
+    negative integer, depending on the direction.  The measurement is given in 
+    milli-g, for example +/- 2g will return +/- 2000mg. 
 
 .. py:function:: get_values()
 
     Get the acceleration measurements in all axes at once, as a three-element
-    The measurement is given in milli-Newtons, for example +/- 2g will return +/- 2000mN. 
+    The measurement is given in milli-g, for example +/- 2g will 
+    return +/- 2000mg. 
 
 .. py:function:: current_gesture()
 

--- a/docs/accelerometer.rst
+++ b/docs/accelerometer.rst
@@ -8,9 +8,10 @@ also provides convenience functions for detecting gestures. The
 recognised gestures are: ``up``, ``down``, ``left``, ``right``, ``face up``,
 ``face down``, ``freefall``, ``3g``, ``6g``, ``8g``, ``shake``.
 
-By default MicroPython sets the accelerometer to +/- 2g, and this can only be
-modified in the DAL layer below. The accelerometer returns a value in the range 
-0..1024 for each axis, which is then scaled accordingly.
+By default MicroPython sets the accelerometer range to +/- 2g, changing the
+accelerometer range is currently not possible in MicroPython.
+The accelerometer returns a value in the range 0..1024 for each axis, which is
+then scaled accordingly.
 
 Functions
 =========
@@ -18,26 +19,30 @@ Functions
 .. py:function:: get_x()
 
     Get the acceleration measurement in the ``x`` axis, as a positive or
-    negative integer, depending on the direction. The measurement is given in 
-    milli-g, for example +/- 2g will return +/- 2000mg. 
+    negative integer, depending on the direction. The measurement is given in
+    milli-g. By default the accelerometer is configured with a range of +/- 2g,
+    and so this method will return within the range of +/- 2000mg.
 
 .. py:function:: get_y()
 
     Get the acceleration measurement in the ``y`` axis, as a positive or
-    negative integer, depending on the direction.  The measurement is given in
-    milli-g, for example +/- 2g will return +/- 2000mg. 
+    negative integer, depending on the direction. The measurement is given in
+    milli-g. By default the accelerometer is configured with a range of +/- 2g,
+    and so this method will return within the range of +/- 2000mg.
 
 .. py:function:: get_z()
 
     Get the acceleration measurement in the ``z`` axis, as a positive or
-    negative integer, depending on the direction.  The measurement is given in 
-    milli-g, for example +/- 2g will return +/- 2000mg. 
+    negative integer, depending on the direction. The measurement is given in
+    milli-g. By default the accelerometer is configured with a range of +/- 2g,
+    and so this method will return within the range of +/- 2000mg.
 
 .. py:function:: get_values()
 
     Get the acceleration measurements in all axes at once, as a three-element
-    The measurement is given in milli-g, for example +/- 2g will 
-    return +/- 2000mg. 
+    tuple of integers ordered as X, Y, Z.
+    By default the accelerometer is configured with a range of +/- 2g, and so
+    X, Y, and Z will be within the range of +/-2000mg.
 
 .. py:function:: current_gesture()
 

--- a/docs/accelerometer.rst
+++ b/docs/accelerometer.rst
@@ -15,24 +15,25 @@ Functions
 .. py:function:: get_x()
 
     Get the acceleration measurement in the ``x`` axis, as a positive or
-    negative integer, depending on the direction.
-
+    negative integer, depending on the direction. 
+    The measurement is given in milli-Newtons, for example +/- 2g will return +/- 2000mN. 
 
 .. py:function:: get_y()
 
     Get the acceleration measurement in the ``y`` axis, as a positive or
     negative integer, depending on the direction.
-
+    The measurement is given in milli-Newtons, for example +/- 2g will return +/- 2000mN. 
 
 .. py:function:: get_z()
 
     Get the acceleration measurement in the ``z`` axis, as a positive or
     negative integer, depending on the direction.
+    The measurement is given in milli-Newtons, for example +/- 2g will return +/- 2000mN. 
 
 .. py:function:: get_values()
 
     Get the acceleration measurements in all axes at once, as a three-element
-    tuple of integers ordered as X, Y, Z.
+    The measurement is given in milli-Newtons, for example +/- 2g will return +/- 2000mN. 
 
 .. py:function:: current_gesture()
 


### PR DESCRIPTION
The measurement is given in milli-Newtons, for example +/- 2g will return +/- 2000mN.