### PR TITLE
lib: Add "bx lr" instruction to end of assembly neopixel function.

### DIFF
--- a/source/lib/neopixelsend.s
+++ b/source/lib/neopixelsend.s
@@ -110,3 +110,4 @@ sendNeopixelBuffer:
     pop {r6}
     msr PRIMASK, r6
     pop {r0, r1, r2, r3, r4, r5, r6}
+    bx lr


### PR DESCRIPTION
Luckily in the output firmware this function was followed by a simple
function that just returned 0, so that's why it worked without this return.