### PR TITLE
module.json: Update to DAL release version 2.1.1.

### DIFF
--- a/module.json
+++ b/module.json
@@ -7,7 +7,7 @@
   "author": "Damien P George <damien.p.george@gmail.com>",
   "homepage": "http://micropython.org",
   "dependencies":{
-    "microbit-dal":"lancaster-university/microbit-dal#v2.1.0"
+    "microbit-dal":"lancaster-university/microbit-dal#v2.1.1"
   },
   "extraIncludes":[
     "inc",


### PR DESCRIPTION
DAL changes can be seen here: https://github.com/lancaster-university/microbit-dal/compare/v2.1.0...v2.1.1

The main things relevant to MicroPython are:
- The delayed error for accelerometer/magnetometer (panic is only raised when the acc/mag methods are used for the first time, instead of during init)
- Radio added 2 new defines to configure the channel max (83) and min(0) frequencies
    - These are the values already used in MicroPython, and since it's not worth including a new header file for just these two defines, we don't need to do anything.
- Radio fixed an issue with the default transmit power not being set correctly (so in v2.1.0 it started very low)
    - The default power used in MicroPython is the same as the DAL, but it's defined internally, so MicroPython was not affected by this bug


We've tested all the features affected, and done a sanity check on the rest of the basic features.

Haven't updated the version in the `module.json` file since we should only edit that when we change the `mpconfigport.h` file.

