### PR TITLE
docs : Improved REPL information regarding serial terminals screen and picocom

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ directory. Unzip it and change to that directory
 ```
 cd ~/Downloads
 unzip micropython-master.zip
-cd micropython-master`
+cd micropython-master
 ```
 
 Once all packages are installed, use yotta and the provided Makefile to build.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@ sudo -H pip3 install yotta
 Download the project, clicking the `Download or clone` button above, then select 
 `Download zip`. This will place a `micropython-master.zip` in your `~/Dowloads`
 directory. Unzip it and change to that directory
-`cd ~/Downloads/micropython-master`
+
+```
+cd ~/Downloads
+unzip micropython-master.zip
+cd micropython-master`
+```
 
 Once all packages are installed, use yotta and the provided Makefile to build.
 You might need need an Arm Mbed account to complete some of the yotta commands,

--- a/README.md
+++ b/README.md
@@ -17,16 +17,11 @@ with an ARM compiler toolchain (eg arm-none-eabi-gcc and friends).
 Ubuntu users can install the needed packages using:
 ```
 sudo add-apt-repository -y ppa:team-gcc-arm-embedded
+sudo add-apt-repository -y ppa:pmiller-opensource/ppa
 sudo apt-get update
-sudo apt-get install gcc-arm-embedded
-sudo apt-get install cmake ninja-build srecord libssl-dev
-sudo -H pip3 install yotta
+sudo apt-get install cmake ninja-build gcc-arm-none-eabi srecord libssl-dev
+pip3 install yotta
 ```
-
-Download the project, clicking the `Download or clone` button above, then select 
-`Download zip`. This will place a `micropython-master.zip` in your `~/Dowloads`
-directory. Unzip it and change to that directory
-`cd ~/Downloads/micropython-master`
 
 Once all packages are installed, use yotta and the provided Makefile to build.
 You might need need an Arm Mbed account to complete some of the yotta commands,

--- a/README.md
+++ b/README.md
@@ -17,11 +17,16 @@ with an ARM compiler toolchain (eg arm-none-eabi-gcc and friends).
 Ubuntu users can install the needed packages using:
 ```
 sudo add-apt-repository -y ppa:team-gcc-arm-embedded
-sudo add-apt-repository -y ppa:pmiller-opensource/ppa
 sudo apt-get update
-sudo apt-get install cmake ninja-build gcc-arm-none-eabi srecord libssl-dev
-pip3 install yotta
+sudo apt-get install gcc-arm-embedded
+sudo apt-get install cmake ninja-build srecord libssl-dev
+sudo -H pip3 install yotta
 ```
+
+Download the project, clicking the `Download or clone` button above, then select 
+`Download zip`. This will place a `micropython-master.zip` in your `~/Dowloads`
+directory. Unzip it and change to that directory
+`cd ~/Downloads/micropython-master`
 
 Once all packages are installed, use yotta and the provided Makefile to build.
 You might need need an Arm Mbed account to complete some of the yotta commands,

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ directory. Unzip it and change to that directory
 ```
 cd ~/Downloads
 unzip micropython-master.zip
-cd micropython-master
+cd micropython-master`
 ```
 
 Once all packages are installed, use yotta and the provided Makefile to build.

--- a/README.md
+++ b/README.md
@@ -26,12 +26,7 @@ sudo -H pip3 install yotta
 Download the project, clicking the `Download or clone` button above, then select 
 `Download zip`. This will place a `micropython-master.zip` in your `~/Dowloads`
 directory. Unzip it and change to that directory
-
-```
-cd ~/Downloads
-unzip micropython-master.zip
-cd micropython-master`
-```
+`cd ~/Downloads/micropython-master`
 
 Once all packages are installed, use yotta and the provided Makefile to build.
 You might need need an Arm Mbed account to complete some of the yotta commands,

--- a/docs/devguide/repl.rst
+++ b/docs/devguide/repl.rst
@@ -81,13 +81,26 @@ In PuTTY:
 Open Terminal and type ``screen /dev/cu.usbmodem1422 115200``, replacing 
 ``/dev/cu.usbmodem1422`` with the port you found earlier. This will open the 
 micro:bit's serial output and show all messages received from the device. To 
-exit, press Ctrl-A then Ctrl-D.
+exit, press Ctrl-A then Ctrl-\ and answer Yes to the question. There are many
+ways back to a command prompt including Ctrl-A then Ctrl-D this will detatch
+screen. All serial output from the micro:bit will still be received by ``screen``.
+Restart screen by typing ``screen -r``. All methods back to a command prompt 
+except Exit leaves a lock on ``/dev/cu.usbmodem1422`` preventing the use of microfs
+(``ufs``) to access files on the micro:bit.  Typing ``screen`` results in rather 
+unhelpful error output ``[screen is terminating]``
 
 
 **Linux**
 
 Using the ``screen`` program, type ``screen /dev/ttyUSB0 115200``, replacing 
-``/dev/ttyUSB0`` with the port you found earlier.
+``/dev/ttyUSB0`` with the port you found earlier.  To exit, press Ctrl-A then
+\ and answer Yes to the question. There are many ways back to a command 
+prompt including Ctrl-A then Ctrl-D this will detatch screen. All serial output
+from the micro:bit will still be received by ``screen``. Restart screen by 
+typing ``screen -r``. All methods back to a command prompt except Exit leaves
+a lock on ``/dev/ttyUSB0`` (or the port you found earlier) preventing the use of microfs
+(``ufs``) to access files on the micro:bit.  Typing ``screen`` results in rather 
+unhelpful error output ``[screen is terminating]``
 
 Using ``picocom``, type ``picocom /dev/ttyACM0 -b 115200``, again replacing 
-``/dev/ttyACM0`` with the port you found earlier. 
+``/dev/ttyACM0`` with the port you found earlier. To exit, press Ctrl-A then Ctrl-Q

--- a/docs/devguide/repl.rst
+++ b/docs/devguide/repl.rst
@@ -96,7 +96,7 @@ Using the ``screen`` program, type ``screen /dev/ttyUSB0 115200``, replacing
 ``/dev/ttyUSB0`` with the port you found earlier.
 
 To exit, press Ctrl-A then \\ and answer Yes to the question. There are many
-ways back to a command prompt including Ctrl-A then Ctrl-D, which will detatch
+ways back to a command prompt including Ctrl-A then Ctrl-D, which will detach
 screen. All serial output from the micro:bit will still be received by
 ``screen``, the serial port will be locked, preventing other applications from
 accessing it. You can restart screen by typing ``screen -r``. Typing

--- a/docs/devguide/repl.rst
+++ b/docs/devguide/repl.rst
@@ -85,7 +85,7 @@ micro:bit's serial output and show all messages received from the device.
 To exit, press Ctrl-A then Ctrl-\\ and answer Yes to the question. There are many
 ways back to a command prompt including Ctrl-A then Ctrl-D, which will detach
 screen. All serial output from the micro:bit will still be received by ``screen``.
-Restart screen by typing ``screen -r``. All methods back to a command prompt 
+You can then restart screen by typing ``screen -r``.
 except Exit leaves a lock on ``/dev/cu.usbmodem1422`` preventing the use of microfs
 (``ufs``) to access files on the micro:bit.  Typing ``screen /dev/cu.usbmodem1422 115200`` 
 results in rather unhelpful error output ``[screen is terminating]``

--- a/docs/devguide/repl.rst
+++ b/docs/devguide/repl.rst
@@ -86,8 +86,8 @@ ways back to a command prompt including Ctrl-A then Ctrl-D this will detatch
 screen. All serial output from the micro:bit will still be received by ``screen``.
 Restart screen by typing ``screen -r``. All methods back to a command prompt 
 except Exit leaves a lock on ``/dev/cu.usbmodem1422`` preventing the use of microfs
-(``ufs``) to access files on the micro:bit.  Typing ``screen`` results in rather 
-unhelpful error output ``[screen is terminating]``
+(``ufs``) to access files on the micro:bit.  Typing ``screen /dev/cu.usbmodem1422 115200`` 
+results in rather unhelpful error output ``[screen is terminating]``
 
 
 **Linux**
@@ -99,8 +99,8 @@ prompt including Ctrl-A then Ctrl-D this will detatch screen. All serial output
 from the micro:bit will still be received by ``screen``. Restart screen by 
 typing ``screen -r``. All methods back to a command prompt except Exit leaves
 a lock on ``/dev/ttyUSB0`` (or the port you found earlier) preventing the use of microfs
-(``ufs``) to access files on the micro:bit.  Typing ``screen`` results in rather 
-unhelpful error output ``[screen is terminating]``
+(``ufs``) to access files on the micro:bit.  Typing ``screen /dev/ttyUSB0 115200`` 
+results in rather unhelpful error output ``[screen is terminating]``
 
 Using ``picocom``, type ``picocom /dev/ttyACM0 -b 115200``, again replacing 
 ``/dev/ttyACM0`` with the port you found earlier. To exit, press Ctrl-A then Ctrl-Q

--- a/docs/devguide/repl.rst
+++ b/docs/devguide/repl.rst
@@ -104,4 +104,6 @@ accessing it. You can restart screen by typing ``screen -r``. Typing
 ``[screen is terminating]``
 
 Using ``picocom``, type ``picocom /dev/ttyACM0 -b 115200``, again replacing
-``/dev/ttyACM0`` with the port you found earlier. To exit, press Ctrl-A then Ctrl-Q.
+``/dev/ttyACM0`` with the port you found earlier.
+
+To exit, press Ctrl-A then Ctrl-Q.

--- a/docs/devguide/repl.rst
+++ b/docs/devguide/repl.rst
@@ -78,31 +78,30 @@ In PuTTY:
 
 **Mac OS**
 
-Open Terminal and type ``screen /dev/cu.usbmodem1422 115200``, replacing 
-``/dev/cu.usbmodem1422`` with the port you found earlier. This will open the 
+Open Terminal and type ``screen /dev/cu.usbmodem1422 115200``, replacing
+``/dev/cu.usbmodem1422`` with the port you found earlier. This will open the
 micro:bit's serial output and show all messages received from the device.
 
-To exit, press Ctrl-A then Ctrl-\\ and answer Yes to the question. There are many
-ways back to a command prompt including Ctrl-A then Ctrl-D, which will detach
-screen, but the serial port with still be locked, preventing other applications from accessing it.
-You can then restart screen by typing ``screen -r``.
-except Exit leaves a lock on ``/dev/cu.usbmodem1422`` preventing the use of microfs
-(``ufs``) to access files on the micro:bit.  Typing ``screen /dev/cu.usbmodem1422 115200`` 
-results in rather unhelpful error output ``[screen is terminating]``
+To exit, press Ctrl-A then Ctrl-\\ and answer Yes to the question. There are
+many ways back to a command prompt including Ctrl-A then Ctrl-D, which will
+detach screen, but the serial port with still be locked, preventing other
+applications from accessing it. You can then restart screen by typing
+``screen -r``. Typing ``screen /dev/cu.usbmodem1422 115200`` results in rather
+unhelpful error output ``[screen is terminating]``
 
 
 **Linux**
 
-Using the ``screen`` program, type ``screen /dev/ttyUSB0 115200``, replacing 
+Using the ``screen`` program, type ``screen /dev/ttyUSB0 115200``, replacing
 ``/dev/ttyUSB0`` with the port you found earlier.
 
-To exit, press Ctrl-A then \\ and answer Yes to the question. There are many ways back to a command 
-prompt including Ctrl-A then Ctrl-D, which will detatch screen. All serial output
-from the micro:bit will still be received by ``screen``. Restart screen by 
-typing ``screen -r``. All methods back to a command prompt except Exit leaves
-a lock on ``/dev/ttyUSB0`` (or the port you found earlier) preventing the use of microfs
-(``ufs``) to access files on the micro:bit.  Typing ``screen /dev/ttyUSB0 115200`` 
-results in rather unhelpful error output ``[screen is terminating]``
+To exit, press Ctrl-A then \\ and answer Yes to the question. There are many
+ways back to a command prompt including Ctrl-A then Ctrl-D, which will detatch
+screen. All serial output from the micro:bit will still be received by
+``screen``, the serial port will be locked, preventing other applications from
+accessing it. You can restart screen by typing ``screen -r``. Typing
+``screen /dev/ttyUSB0 115200`` results in rather unhelpful error output
+``[screen is terminating]``
 
-Using ``picocom``, type ``picocom /dev/ttyACM0 -b 115200``, again replacing 
+Using ``picocom``, type ``picocom /dev/ttyACM0 -b 115200``, again replacing
 ``/dev/ttyACM0`` with the port you found earlier. To exit, press Ctrl-A then Ctrl-Q.

--- a/docs/devguide/repl.rst
+++ b/docs/devguide/repl.rst
@@ -84,7 +84,7 @@ micro:bit's serial output and show all messages received from the device.
 
 To exit, press Ctrl-A then Ctrl-\\ and answer Yes to the question. There are many
 ways back to a command prompt including Ctrl-A then Ctrl-D, which will detach
-screen. All serial output from the micro:bit will still be received by ``screen``.
+screen, but the serial port with still be locked, preventing other applications from accessing it.
 You can then restart screen by typing ``screen -r``.
 except Exit leaves a lock on ``/dev/cu.usbmodem1422`` preventing the use of microfs
 (``ufs``) to access files on the micro:bit.  Typing ``screen /dev/cu.usbmodem1422 115200`` 

--- a/docs/devguide/repl.rst
+++ b/docs/devguide/repl.rst
@@ -86,8 +86,7 @@ To exit, press Ctrl-A then Ctrl-\\ and answer Yes to the question. There are
 many ways back to a command prompt including Ctrl-A then Ctrl-D, which will
 detach screen, but the serial port with still be locked, preventing other
 applications from accessing it. You can then restart screen by typing
-``screen -r``. Typing ``screen /dev/cu.usbmodem1422 115200`` results in rather
-unhelpful error output ``[screen is terminating]``
+``screen -r``.
 
 
 **Linux**
@@ -99,9 +98,7 @@ To exit, press Ctrl-A then \\ and answer Yes to the question. There are many
 ways back to a command prompt including Ctrl-A then Ctrl-D, which will detach
 screen. All serial output from the micro:bit will still be received by
 ``screen``, the serial port will be locked, preventing other applications from
-accessing it. You can restart screen by typing ``screen -r``. Typing
-``screen /dev/ttyUSB0 115200`` results in rather unhelpful error output
-``[screen is terminating]``
+accessing it. You can restart screen by typing ``screen -r``.
 
 Using ``picocom``, type ``picocom /dev/ttyACM0 -b 115200``, again replacing
 ``/dev/ttyACM0`` with the port you found earlier.

--- a/docs/devguide/repl.rst
+++ b/docs/devguide/repl.rst
@@ -105,4 +105,4 @@ a lock on ``/dev/ttyUSB0`` (or the port you found earlier) preventing the use of
 results in rather unhelpful error output ``[screen is terminating]``
 
 Using ``picocom``, type ``picocom /dev/ttyACM0 -b 115200``, again replacing 
-``/dev/ttyACM0`` with the port you found earlier. To exit, press Ctrl-A then Ctrl-Q
+``/dev/ttyACM0`` with the port you found earlier. To exit, press Ctrl-A then Ctrl-Q.

--- a/docs/devguide/repl.rst
+++ b/docs/devguide/repl.rst
@@ -82,7 +82,7 @@ Open Terminal and type ``screen /dev/cu.usbmodem1422 115200``, replacing
 ``/dev/cu.usbmodem1422`` with the port you found earlier. This will open the 
 micro:bit's serial output and show all messages received from the device. To 
 exit, press Ctrl-A then Ctrl-\\ and answer Yes to the question. There are many
-ways back to a command prompt including Ctrl-A then Ctrl-D this will detatch
+ways back to a command prompt including Ctrl-A then Ctrl-D, which will detach
 screen. All serial output from the micro:bit will still be received by ``screen``.
 Restart screen by typing ``screen -r``. All methods back to a command prompt 
 except Exit leaves a lock on ``/dev/cu.usbmodem1422`` preventing the use of microfs

--- a/docs/devguide/repl.rst
+++ b/docs/devguide/repl.rst
@@ -80,8 +80,9 @@ In PuTTY:
 
 Open Terminal and type ``screen /dev/cu.usbmodem1422 115200``, replacing 
 ``/dev/cu.usbmodem1422`` with the port you found earlier. This will open the 
-micro:bit's serial output and show all messages received from the device. To 
-exit, press Ctrl-A then Ctrl-\\ and answer Yes to the question. There are many
+micro:bit's serial output and show all messages received from the device.
+
+To exit, press Ctrl-A then Ctrl-\\ and answer Yes to the question. There are many
 ways back to a command prompt including Ctrl-A then Ctrl-D, which will detach
 screen. All serial output from the micro:bit will still be received by ``screen``.
 Restart screen by typing ``screen -r``. All methods back to a command prompt 
@@ -93,9 +94,10 @@ results in rather unhelpful error output ``[screen is terminating]``
 **Linux**
 
 Using the ``screen`` program, type ``screen /dev/ttyUSB0 115200``, replacing 
-``/dev/ttyUSB0`` with the port you found earlier.  To exit, press Ctrl-A then
-\\ and answer Yes to the question. There are many ways back to a command 
-prompt including Ctrl-A then Ctrl-D this will detatch screen. All serial output
+``/dev/ttyUSB0`` with the port you found earlier.
+
+To exit, press Ctrl-A then \\ and answer Yes to the question. There are many ways back to a command 
+prompt including Ctrl-A then Ctrl-D, which will detatch screen. All serial output
 from the micro:bit will still be received by ``screen``. Restart screen by 
 typing ``screen -r``. All methods back to a command prompt except Exit leaves
 a lock on ``/dev/ttyUSB0`` (or the port you found earlier) preventing the use of microfs

--- a/docs/devguide/repl.rst
+++ b/docs/devguide/repl.rst
@@ -81,7 +81,7 @@ In PuTTY:
 Open Terminal and type ``screen /dev/cu.usbmodem1422 115200``, replacing 
 ``/dev/cu.usbmodem1422`` with the port you found earlier. This will open the 
 micro:bit's serial output and show all messages received from the device. To 
-exit, press Ctrl-A then Ctrl-\ and answer Yes to the question. There are many
+exit, press Ctrl-A then Ctrl-\\ and answer Yes to the question. There are many
 ways back to a command prompt including Ctrl-A then Ctrl-D this will detatch
 screen. All serial output from the micro:bit will still be received by ``screen``.
 Restart screen by typing ``screen -r``. All methods back to a command prompt 
@@ -94,7 +94,7 @@ unhelpful error output ``[screen is terminating]``
 
 Using the ``screen`` program, type ``screen /dev/ttyUSB0 115200``, replacing 
 ``/dev/ttyUSB0`` with the port you found earlier.  To exit, press Ctrl-A then
-\ and answer Yes to the question. There are many ways back to a command 
+\\ and answer Yes to the question. There are many ways back to a command 
 prompt including Ctrl-A then Ctrl-D this will detatch screen. All serial output
 from the micro:bit will still be received by ``screen``. Restart screen by 
 typing ``screen -r``. All methods back to a command prompt except Exit leaves


### PR DESCRIPTION
The documentation to terminate serial terminal `screen` were incorrect
the documentation to terminate `picocom` didn't exist  