### PR TITLE
Use full yotta command (not yt) during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ $(HEX_FINAL): yotta $(VER_ADDR_FILE)
 	@size $(HEX_SRC:.hex=)
 
 yotta: $(MBIT_VER_FILE)
-	@yt build
+	@yotta build
 
 $(MBIT_VER_FILE): FORCE
 	python tools/makeversionhdr.py $(MBIT_VER_FILE)

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ if so, you could be prompted to create one as a part of the process.
 - Use target bbc-microbit-classic-gcc-nosd:
 
   ```
-  yt target bbc-microbit-classic-gcc-nosd
+  yotta target bbc-microbit-classic-gcc-nosd
   ```
 
 - Run yotta update to fetch remote assets:
 
   ```
-  yt up
+  yotta up
   ```
 
 - Start the build:


### PR DESCRIPTION
yotta is now packaged for Debian testing/unstable, and should be available to install via apt in the forthcoming stable releases of Debian 10 "Buster" and Ubuntu 19.04 "Disco Dingo".

When yotta is installed via the apt package manager on Debian/Ubuntu, the `yt` shorthand alternative for the yotta command is unavailable due to a clash with an identically-named command from the python3-yt package.

This update ensures the default yotta command is used when building MicroPython via the Makefile, and updates the README to use the full yotta command.