### PR TITLE
Incorrect SI unit?

### DIFF
--- a/docs/audio.rst
+++ b/docs/audio.rst
@@ -52,7 +52,7 @@ Technical Details
     You don't need to understand this section to use the ``audio`` module.
     It is just here in case you wanted to know how it works.
 
-The ``audio`` module consumes samples at 7812.5 kHz, and uses linear interpolation to
+The ``audio`` module consumes samples at 7812.5 Hz, and uses linear interpolation to
 output a PWM signal at 32.5 kHz, which gives tolerable sound quality.
 
 The function ``play`` fully copies all data from each ``AudioFrame`` before it


### PR DESCRIPTION
The "Technical Details" section says 7800 kHz samples are consumed per second, but the overview states 7812.5 samples per second.

Either it is 7812.5 Hz, or 7.8125 kHz, I presume?