### PR TITLE
docs: fix the table in pin.rst to match the diagram

### DIFF
--- a/docs/pin.rst
+++ b/docs/pin.rst
@@ -43,13 +43,13 @@ module:``microbit.pin0`` - ``microbit.pin20``.
 +-----+---------+----------+
 |  5  | Digital | Button A |
 +-----+---------+----------+
-|  6  | Digital | Row 2    |
+|  6  | Digital | Column 9 |
 +-----+---------+----------+
-|  7  | Digital | Row 1    |
+|  7  | Digital | Column 8 |
 +-----+---------+----------+
 |  8  | Digital |          |
 +-----+---------+----------+
-|  9  | Digital | Row 3    |
+|  9  | Digital | Column 7 |
 +-----+---------+----------+
 |  10 | Analog  | Column 3 |
 +-----+---------+----------+
@@ -57,11 +57,11 @@ module:``microbit.pin0`` - ``microbit.pin20``.
 +-----+---------+----------+
 |  12 | Digital |          |
 +-----+---------+----------+
-|  13 | Digital | SPI MOSI |
+|  13 | Digital | SPI SCK  |
 +-----+---------+----------+
 |  14 | Digital | SPI MISO |
 +-----+---------+----------+
-|  15 | Digital | SPI SCK  |
+|  15 | Digital | SPI MOSI |
 +-----+---------+----------+
 |  16 | Digital |          |
 +-----+---------+----------+


### PR DESCRIPTION
The pin table in `pins.rst` disagrees with the diagram:

 - it says three of the edge connector pins are for the LED rows, rather than columns 7, 8, and 9;
 - it has the three SPI pins in the opposite order

I think the diagram is right and the table is wrong:

 - [pinmap.csv] says the three LED pins are internal GPIOs 10,11,12 which are definitely columns;
 - spi.rst has sclk=pin13, mosi=pin15, miso=pin14 .

[pinmap.csv]: https://tech.microbit.org/docs/hardware/pinmap.csv
