### PR TITLE
Docs: remove reference to windows driver

### DIFF
--- a/docs/devguide/repl.rst
+++ b/docs/devguide/repl.rst
@@ -12,11 +12,6 @@ Accessing the REPL on the micro:bit will require you to:
 * Determine the communication port identifier for the micro:bit
 * Use a program to establish communication with the device
 
-For versions of Windows before 10 you might need to install the Mbed serial 
-driver, the instructions for which are found here:
-
-https://os.mbed.com/docs/latest/tutorials/windows-serial-driver.html
-
 
 Using a serial communication program
 ------------------------------------


### PR DESCRIPTION
as per Foundation ticket microbit-foundation/platform-software-issue-tracker#582 Windows 7 reaches EOL in Jan 2020 and we no longer want to recommend  installing the mBED driver as it conflicts with later versions of  Windows


