### PR TITLE
Support RGBW WS2812 neopixels

### DIFF
--- a/source/lib/neopixelsend.s
+++ b/source/lib/neopixelsend.s
@@ -27,7 +27,7 @@
 
 .global sendNeopixelBuffer
 
- /* declared as extern void sendBuffer(uint32_t pin, uint8_t* data_address, uint16_t num_leds) */
+ /* declared as extern void sendBuffer(uint32_t pin, uint8_t* data_address, uint16_t num_leds, uint16_t num_channels) */
 
 sendNeopixelBuffer:
     push {r0, r1, r2, r3, r4, r5, r6}
@@ -37,19 +37,20 @@ sendNeopixelBuffer:
     r0 = pinmask to waggle in the GPIO register
     r1 = address of the data we are supposed to be sending
     r2 = number of LEDs
+    r3 = number of channels each LED has (aka bytes per pixel)
 
     Setup the initial values
      r1 = Pin mask in the GPIO register
      r2 = GPIO clear register
      r3 = GPIO SET
      r4 = Address pointer for the data - we cast this as a byte earlier because it really is.
-     r5 = Length of the data (number of LEDS * 3 bytes per LED) - If trying to add RGB+W this sum might need to be done conditionally
-     r6 = Parallel to serial conversion mask
+     r5 = Length of the data (number of LEDS * 3-4 bytes per LED)
+     r6 = Parallel to serial conversion mask (seems to just correspond to number of channels)
     */
-    mov r4, r1
-    mov r6, #3
-    mul r6, r2, r6
-    mov r5, r6
+    mov r6, r3 //moves imported channel value into serial conversion mask 
+    mov r4, r1 //Move pinmask (r1) into address pointer
+    mul r6, r2, r6 //multiply parallel mask by number of LEDs to get length of data in bytes.
+    mov r5, r6 //move it into the r5 register for use.
 
     /*load the pin set and clr addresses by a cunning combo of shifts and adds*/
     movs r3, #160
@@ -68,14 +69,14 @@ sendNeopixelBuffer:
     If it is a '0' we turn off the pin asap and then move to the code that advances to the next bit/byte. If a '1' we leave the pin on and do the same thing.
     If the mask (r6) is still valid then we are still moving out the current byte, so repeat.
     If it is '0' then we have done this byte and need to load the next byte from the pointer in r4.
-    r5 contains the count of bytes - calculated above from num LEDs * 3 bytes per LED.
-    --If this code needs to do RGB+W LEDS then that will need to be addressed.
+    r5 contains the count of bytes - calculated above from num LEDs * 3-4 bytes per LED (depending on num_channels).
     Once we run r5 down to '0' we exit the data shifting and return.
     */
 
     mrs r6, PRIMASK /* disable interrupts whilst we mess with timing critical waggling. */
     push {r6}
     cpsid i
+    
 
     b .start
 

--- a/source/microbit/modneopixel.cpp
+++ b/source/microbit/modneopixel.cpp
@@ -34,45 +34,57 @@ extern "C" {
 #include "py/runtime.h"
 #include "microbit/modmicrobit.h"
 
-// This is the pixel colour ordering
-#define COL_NUM_COMPONENTS (3)
+// This is the pixel channel colour ordering       |R G B W|
+// WS8212/WS8212B chips use GRB-W ordering, hence: |1 0 2 3|
 #define COL_IDX_RED (1)
 #define COL_IDX_GREEN (0)
 #define COL_IDX_BLUE (2)
+#define COL_IDX_WHITE (3)
 
+// sends bytes to pixels
 // This is implemented in assembler to get the right timing
-extern void sendNeopixelBuffer(uint32_t pin, uint8_t* data_address, uint16_t num_leds);
+extern void sendNeopixelBuffer(uint32_t pin, uint8_t* data_address, uint16_t num_leds, uint16_t channels);
 
 extern const mp_obj_type_t neopixel_type;
 
+//Input args when calling neopixel.NeoPixel()?
 typedef struct _neopixel_obj_t {
     mp_obj_base_t base;
     uint16_t pin_num;
     uint16_t num_pixels;
+    uint16_t num_channels;
     uint8_t data[];
 } neopixel_obj_t;
 
 STATIC mp_obj_t neopixel_show_(mp_obj_t self_in);
 
 static inline void neopixel_clear_data(neopixel_obj_t *self) {
-    memset(&self->data[0], 0, COL_NUM_COMPONENTS * self->num_pixels);
+    memset(&self->data[0], 0, self->num_channels * self->num_pixels);
 }
 
 STATIC mp_obj_t neopixel_make_new(const mp_obj_type_t *type_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
     (void)type_in;
-    mp_arg_check_num(n_args, n_kw, 2, 2, false);
+    mp_arg_check_num(n_args, n_kw, 3, 3, false);
 
+
+    //TODO: Figure out how kword args work and implement a channels= or similar arg for more pythonic code
     PinName pin = (PinName)microbit_obj_get_pin_name(args[0]);
     mp_int_t num_pixels = mp_obj_get_int(args[1]);
+    mp_int_t num_channels = mp_obj_get_int(args[2]);
 
     if (num_pixels <= 0) {
         mp_raise_ValueError("invalid number of pixels");
     }
+    //at the moment only 3 or 4 channels are supported. Better to implement as bool?
+    if (num_channels != 3 && num_channels != 4){
+        mp_raise_ValueError("Invalid number of channels! Try 3 (RGB) or 4 (RGB-W)");
+    }
 
-    neopixel_obj_t *self = m_new_obj_var(neopixel_obj_t, uint8_t, COL_NUM_COMPONENTS * num_pixels);
+    neopixel_obj_t *self = m_new_obj_var(neopixel_obj_t, uint8_t, num_channels * num_pixels);
     self->base.type = &neopixel_type;
     self->pin_num = pin;
     self->num_pixels = num_pixels;
+    self->num_channels = num_channels;
     neopixel_clear_data(self);
 
     // Configure pin as output and set it low
@@ -90,38 +102,70 @@ STATIC mp_obj_t neopixel_unary_op(mp_uint_t op, mp_obj_t self_in) {
     }
 }
 
+
+//this is called when operating on pixel list (data[i] or similar) in python
 STATIC mp_obj_t neopixel_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value) {
     neopixel_obj_t *self = (neopixel_obj_t*)self_in;
     mp_uint_t index = mp_get_index(self->base.type, self->num_pixels, index_in, false);
-    index *= COL_NUM_COMPONENTS;
+    index *= self->num_channels;
+
+
     if (value == MP_OBJ_NULL) {
         // delete item
         return MP_OBJ_NULL; // op not supported
     } else if (value == MP_OBJ_SENTINEL) {
-        // load
-        mp_obj_t rgb[COL_NUM_COMPONENTS] = {
+        // load and return color tuple at index
+
+        //create the tuple with 4 channels regardless of how many we actually wanted.
+        //num_channels variable will simply cut off the last channel if it's 3.
+        mp_obj_t rgbw[self->num_channels] = {
             MP_OBJ_NEW_SMALL_INT(self->data[index + COL_IDX_RED]),
             MP_OBJ_NEW_SMALL_INT(self->data[index + COL_IDX_GREEN]),
             MP_OBJ_NEW_SMALL_INT(self->data[index + COL_IDX_BLUE]),
+            MP_OBJ_NEW_SMALL_INT(self->data[index + COL_IDX_WHITE]),
         };
-        return mp_obj_new_tuple(COL_NUM_COMPONENTS, rgb);
+
+
+        return mp_obj_new_tuple(self->num_channels, rgbw);
     } else {
-        // store
-        mp_obj_t *rgb;
-        mp_obj_get_array_fixed_n(value, COL_NUM_COMPONENTS, &rgb);
-        mp_int_t r = mp_obj_get_int(rgb[0]);
-        mp_int_t g = mp_obj_get_int(rgb[1]);
-        mp_int_t b = mp_obj_get_int(rgb[2]);
-        if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255) {
-            mp_raise_ValueError("invalid colour");
+        // store the assigned tuple at the given index. 
+        // Stored internally as a continuous array, with each channel at a certain offset to the index.
+        mp_obj_t *rgbw;
+        mp_obj_get_array_fixed_n(value, self->num_channels, &rgbw);
+        mp_int_t r = mp_obj_get_int(rgbw[0]);
+        mp_int_t g = mp_obj_get_int(rgbw[1]);
+        mp_int_t b = mp_obj_get_int(rgbw[2]);
+
+        //check if the number of channels passed is 3, then check for valid data range:
+        if (self->num_channels == 3) {
+            if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255) {
+                mp_raise_ValueError("invalid colour");
+            }
         }
+        //we always create 3 channels, regardless of number specified in num_channels (misleading?)
         self->data[index + COL_IDX_RED] = r;
         self->data[index + COL_IDX_GREEN] = g;
         self->data[index + COL_IDX_BLUE] = b;
+
+        //check whether a 4th 'white' channel needs to be appended and stored (somewhat hacky!)
+        if (self->num_channels == 4){
+
+            mp_int_t w = mp_obj_get_int(rgbw[3]);
+
+            //for RGB+W WS8212 pixels, the W channel can either be 255 or 0. Intermediate values cause flickering
+            //Question: Do we allow users to do this behaviour anyway or restrict to a boolean value?
+            if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255 || w < 0 || w > 255) {
+                mp_raise_ValueError("invalid colour");
+            }
+
+        self->data[index + COL_IDX_WHITE] = w;
+
+        }
+
         return mp_const_none;
     }
 }
-
+//shorthand function to wipe data list and call show() again - effectively turning off pixels.
 STATIC mp_obj_t neopixel_clear_(mp_obj_t self_in) {
     neopixel_obj_t *self = (neopixel_obj_t*)self_in;
     neopixel_clear_data(self);
@@ -130,6 +174,7 @@ STATIC mp_obj_t neopixel_clear_(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(neopixel_clear_obj, neopixel_clear_);
 
+//actually executes changes made to data list. Corresponds to .show()
 STATIC mp_obj_t neopixel_show_(mp_obj_t self_in) {
     neopixel_obj_t *self = (neopixel_obj_t*)self_in;
 
@@ -137,12 +182,14 @@ STATIC mp_obj_t neopixel_show_(mp_obj_t self_in) {
     // Be aware that this runs with interrupts off.
     uint32_t pin_mask = (1UL << self->pin_num);
     NRF_GPIO->OUTCLR = pin_mask;
-    sendNeopixelBuffer(pin_mask, &self->data[0], self->num_pixels);
+    sendNeopixelBuffer(pin_mask, &self->data[0], self->num_pixels, self->num_channels);
 
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_1(neopixel_show_obj, neopixel_show_);
 
+//maps internal methods to python Q-Strings. 
+//don't quite understand how this work but assume text after QSTR_ is the name (e.g. MP_QSTR_clear = .clear())
 STATIC const mp_map_elem_t neopixel_locals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_clear), (mp_obj_t)&neopixel_clear_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_show), (mp_obj_t)&neopixel_show_obj },
@@ -150,6 +197,7 @@ STATIC const mp_map_elem_t neopixel_locals_dict_table[] = {
 
 STATIC MP_DEFINE_CONST_DICT(neopixel_locals_dict, neopixel_locals_dict_table);
 
+//Internal stuff for defining python object structure?
 const mp_obj_type_t neopixel_type = {
     { &mp_type_type },
     .name = MP_QSTR_NeoPixel,


### PR DESCRIPTION
This patch adds support for RGB-W WS2812 neopixel components. 

NeoPixel constructor now takes 3 arguments (pin, num_leds, num_channels). num_channels is used to determine whether an extra white channel needs to be sent to the LED chip. 

neopixelsend.s assembly also now takes num_channels as a parameter in R3 to use as "parallel - serial conversion mask" in R6 instead of hardcoding value.

Commenting was largely for my own benefit deciphering the micropython internal structure and so may be untidy/uncertain. 