### PR TITLE
Docs: update for RGBW neopixel

### DIFF
--- a/docs/neopixel.rst
+++ b/docs/neopixel.rst
@@ -14,7 +14,7 @@ need to import it separately with::
     From our tests, the micro:bit NeoPixel module can drive up to around 256
     NeoPixels. Anything above that and you may experience weird bugs and
     issues. The micro:bit can only supply 90mA **V1** or 190mA **V2**  to
-    external devices,larger numbers of NeoPixels require an external power
+    external devices, larger numbers of NeoPixels require an external power
     supply with common ground.
 
     NeoPixels are designed to work at 5V, but luckily they still function using

--- a/docs/neopixel.rst
+++ b/docs/neopixel.rst
@@ -11,10 +11,10 @@ need to import it separately with::
 
 .. note::
 
-    From our tests, the micro:bit NeoPixel module can drive up to around 256
+    From our tests, the Microbit NeoPixel module can drive up to around 256
     NeoPixels. Anything above that and you may experience weird bugs and
     issues. The micro:bit can only supply 90mA **V1** or 190mA **V2**  to
-    external devices, larger numbers of NeoPixels require an external power
+    external devices,larger numbers of NeoPixels require an external power
     supply with common ground.
 
     NeoPixels are designed to work at 5V, but luckily they still function using
@@ -54,9 +54,10 @@ Classes
     NeoPixel(pin, n, bpp)
 
     Initialise a new strip of ``n`` number of neopixel LEDs controlled via pin
-    ``pin``. For **V2** micro:bit boards that support RGBW neopixels, a third
-    value can be passed to ``NeoPixel`` to indicate the number of bytes per
-    pixel (bpp) is 4 rather than the default of 3.
+    ``pin``. The **V2** micro:bit can also support RGBW neopixels, so a third
+    argument can be passed to ``NeoPixel`` to indicate the number of bytes per
+    pixel (bpp). For RGBW, this is is ``4`` rather than the default of 3 for
+    RGB and GRB.
     
     Each pixel is addressed by a position (starting from 0). Neopixels
     are given RGB (red, green, blue) / RGBW (red, green, blue, white) **V2**

--- a/docs/neopixel.rst
+++ b/docs/neopixel.rst
@@ -4,7 +4,7 @@ NeoPixel
 .. py:module:: neopixel
 
 The ``neopixel`` module lets you use NeoPixel (WS2812) individually addressable
-RGB LED strips with the micro:bit. Note to use the ``neopixel`` module, you
+RGB and RGBW **V2** LED strips with the micro:bit. Note to use the ``neopixel`` module, you
 need to import it separately with::
 
     import neopixel
@@ -13,9 +13,9 @@ need to import it separately with::
 
     From our tests, the Microbit NeoPixel module can drive up to around 256
     NeoPixels. Anything above that and you may experience weird bugs and
-    issues. As the micro:bit can only supply 90mA to external devices,
-    larger numbers of NeoPixels require an external power supply with common
-    ground.
+    issues. The micro:bit can only supply 90mA **V1** or 190mA **V2**  to
+    external devices,larger numbers of NeoPixels require an external power
+    supply with common ground.
 
     NeoPixels are designed to work at 5V, but luckily they still function using
     the 3V supply of the BBC micro:bit. Please note that the micro:bit edge
@@ -51,11 +51,16 @@ Classes
 
 .. py:class::
     NeoPixel(pin, n)
+    NeoPixel(pin, n, 4)
 
     Initialise a new strip of ``n`` number of neopixel LEDs controlled via pin
-    ``pin``. Each pixel is addressed by a position (starting from 0). Neopixels
-    are given RGB (red, green, blue) values between 0-255 as a tuple. For
-    example, ``(255,255,255)`` is white.
+    ``pin``. For **V2** micro:bit boards that support RGBW neopixels, a third
+    value can be passed to ``NeoPixel`` to indicate the number of positions
+    
+    Each pixel is addressed by a position (starting from 0). Neopixels
+    are given RGB (red, green, blue) / RGBW (red, green, blue, white) **V2**
+    values between 0-255 as a tuple. For example, in RGB, ``(255,255,255)`` is
+    white. In RGBW, ``(255,255,255,0)`` or ``(0,0,0,255)`` is white.
 
     .. py:method:: clear()
 
@@ -87,10 +92,10 @@ Using Neopixels
 ===============
 
 Interact with Neopixels as if they were a list of tuples. Each tuple represents
-the RGB (red, green and blue) mix of colours for a specific pixel. The RGB
-values can range between 0 to 255.
+the RGB (red, green and blue) / RGBW (red, green,blue and white) mix of colours
+for a specific pixel. The RGBW values can range between 0 to 255.
 
-For example, initialise a strip of 8 neopixels on a strip connected to pin0
+For example, initialise a strip of 8 RGB neopixels on a strip connected to pin0
 like this::
 
     import neopixel

--- a/docs/neopixel.rst
+++ b/docs/neopixel.rst
@@ -51,12 +51,12 @@ Classes
 
 .. py:class::
     NeoPixel(pin, n)
-    NeoPixel(pin, n, 4)
+    NeoPixel(pin, n, bpp)
 
     Initialise a new strip of ``n`` number of neopixel LEDs controlled via pin
     ``pin``. For **V2** micro:bit boards that support RGBW neopixels, a third
     value can be passed to ``NeoPixel`` to indicate the number of bytes per
-    pixel is 4 rather than the default of 3.
+    pixel (bpp) is 4 rather than the default of 3.
     
     Each pixel is addressed by a position (starting from 0). Neopixels
     are given RGB (red, green, blue) / RGBW (red, green, blue, white) **V2**

--- a/docs/neopixel.rst
+++ b/docs/neopixel.rst
@@ -27,6 +27,8 @@ contains everything to plug them into a micro:bit and create funky displays,
 art and games such as the demo shown below.
 
 .. image:: neopixel.gif
+   :alt: Neopixel flexible tile
+Image attribution: `adafruit flexible Neopixel matrix <https://www.adafruit.com/product/2547>`_
 
 To connect a strip of neopixels you'll need to attach the micro:bit as shown
 below (assuming you want to drive the pixels from pin 0 - you can connect

--- a/docs/neopixel.rst
+++ b/docs/neopixel.rst
@@ -72,9 +72,18 @@ Classes
 
 
     .. py:method:: show()
+                   write()
 
         Show the pixels. Must be called for any updates to become visible.
+        For micro:bit **V2**, the additional ``write()`` method is
+        available as part of the RGBW implementation and is equivalent
+        to ``show()``
 
+    .. py:method:: fill((r,g,b))
+
+        **V2** Colour all pixels a given RGB/RGBW value. Use in conjunction with
+        ``show()`` to update the Neopixels.
+    
 Operations
 ==========
 

--- a/docs/neopixel.rst
+++ b/docs/neopixel.rst
@@ -55,7 +55,8 @@ Classes
 
     Initialise a new strip of ``n`` number of neopixel LEDs controlled via pin
     ``pin``. For **V2** micro:bit boards that support RGBW neopixels, a third
-    value can be passed to ``NeoPixel`` to indicate the number of positions
+    value can be passed to ``NeoPixel`` to indicate the number of bytes per
+    pixel is 4 rather than the default of 3.
     
     Each pixel is addressed by a position (starting from 0). Neopixels
     are given RGB (red, green, blue) / RGBW (red, green, blue, white) **V2**

--- a/docs/neopixel.rst
+++ b/docs/neopixel.rst
@@ -75,13 +75,14 @@ Classes
                    write()
 
         Show the pixels. Must be called for any updates to become visible.
-        For micro:bit **V2**, the additional ``write()`` method is
-        available as part of the RGBW implementation and is equivalent
-        to ``show()``
+        For micro:bit **V2**, an additional ``write()`` method is
+        available and is equivalent to ``show()``
 
-    .. py:method:: fill((r,g,b))
+    .. py:method:: fill(colour)
 
-        **V2** Colour all pixels a given RGB/RGBW value. Use in conjunction with
+        **V2** Colour all pixels a given RGB/RGBW value. The `colour` argument
+        should be a tuple of the same length as the mumber of bytes per pixel
+        (bpp). For example ``fill((0,0,255))``. Use in conjunction with
         ``show()`` to update the Neopixels.
     
 Operations

--- a/docs/neopixel.rst
+++ b/docs/neopixel.rst
@@ -11,7 +11,7 @@ need to import it separately with::
 
 .. note::
 
-    From our tests, the Microbit NeoPixel module can drive up to around 256
+    From our tests, the micro:bit NeoPixel module can drive up to around 256
     NeoPixels. Anything above that and you may experience weird bugs and
     issues. The micro:bit can only supply 90mA **V1** or 190mA **V2**  to
     external devices,larger numbers of NeoPixels require an external power


### PR DESCRIPTION
Doc update to include support for RGBW Neopixels. I haven't tested this on hardware, so making an assumption that the values are in the order written eg `np[0]= (R, G, B, W)` as opposed to GRBW which I think is the default for NeoPixelsand we order them here https://github.com/microbit-foundation/micropython-microbit-v2/blob/6a4b97ffce97a41a593e77553a82e24e59b7107c/src/codal_port/modules/neopixel.py#L19