### PR TITLE
Partially fixed kode example in 'How to use'

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Upon reset you will have a REPL on the USB CDC serial port, with baudrate
 
 Then try:
 
-    >>> import microbit
-    >>> microbit.display.scroll('hello!')
-    >>> microbit.button_a.is_pressed()
+    >>> from microbit import *
+    >>> display.scroll('hello!')
+    >>> button_a.is_pressed()
     >>> dir(microbit)
 
 Tab completion works and is very useful!


### PR DESCRIPTION
A non-existing function named "microbit" was causing a NameError.
Changed [Import microbit] to [from microbit import *].
NB! "dir(microbit)" is still making a NameError, since microbit isn't defined or a pre-existing function. I am not sure what this line is meant to do, so I've let it be.