### PR TITLE
update pin_speaker context

### DIFF
--- a/docs/pin.rst
+++ b/docs/pin.rst
@@ -79,7 +79,9 @@ in MicroPython, but that are not available via the edge connector:
 * ``pin_logo`` - A touch sensitive logo pin on the front of the micro:bit,
   which by default is set to capacitive touch mode.
 
-* ``pin_speaker`` - A pin to address the micro:bit speaker.
+* ``pin_speaker`` - A pin to address the micro:bit speaker. This API is
+  intended only for use in Pulse-Width Modulation pin operations eg.
+  ``pin_speaker.write_analog(128)``.
 
 
 Pulse-Width Modulation


### PR DESCRIPTION
Let people know that `pin_speaker` is designed only for PWM use.

There is also a reference to pin_speaker in https://github.com/bbcmicrobit/micropython/blob/v2-docs/docs/microbit_micropython_api.rst#pins but I think this is still valid