### PR TITLE
Fix image_shift

### DIFF
--- a/source/microbit/microbitimage.cpp
+++ b/source/microbit/microbitimage.cpp
@@ -322,8 +322,8 @@ STATIC void image_blit(microbit_image_obj_t *src, greyscale_t *dest, mp_int_t x,
 }
 
 greyscale_t *image_shift(microbit_image_obj_t *self, mp_int_t x, mp_int_t y) {
-    greyscale_t *result = greyscale_new(self->width(), self->width());
-    image_blit(self, result, x, y, self->width(), self->width(), 0, 0);
+    greyscale_t *result = greyscale_new(self->width(), self->height());
+    image_blit(self, result, x, y, self->width(), self->height(), 0, 0);
     return result;
 }
 


### PR DESCRIPTION
This pull request fixes an issue I submitted a few days ago (#718) about a bug I found in the image_shift function that caused it to unintentionally change the size of an image. This is my first time submitting a pull request to an open source project so any feedback would be appreciated.