### PR TITLE
Docs: Update info on python.microbit.org

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,20 +25,21 @@ you enjoy developing for the BBC micro:bit using MicroPython.
     **V2**.
 
 If you're a new programmer, teacher or unsure where to start, begin with the
-tutorials.
-
-.. image:: comic.png
+:ref:`Tutorials <Tutorials>` and use the `micro:bit Python Editor <https://python.microbit.org>`_
+to program the micro:bit. 
 
 .. note::
 
-    This project is under active development. Please help other
-    developers by adding tips, how-tos, and Q&A to this document.
-    Thanks!
+   MicroPython will not work in the MakeCode editor, as this
+   uses a `different version of Python. <https://support.microbit.org/support/solutions/articles/19000111744-makecode-python-and-micropython>`_
+
+.. image:: comic.png
 
 Projects related to MicroPython on the BBC micro:bit include:
 
 * `micro:bit Python Editor <https://python.microbit.org>`_ A simple
-  browser-based code editor, designed to help teachers and learners get the
+  browser-based code editor, developed by the Micro:bit Educational
+  Foundation  and designed to help teachers and learners get the
   most out of text-based programming on the micro:bit.
 
 * `Mu <https://codewith.mu>`_ A simple offline code editor for kids, teachers

--- a/docs/tutorials/introduction.rst
+++ b/docs/tutorials/introduction.rst
@@ -1,18 +1,17 @@
 Introduction
 ------------
+.. _Tutorials:
 
-We suggest you download and use the `mu editor <http://codewith.mu/>`_ when
-working through these tutorials. Instructions for downloading and installing
-Mu are on its website. You may need to install a driver, depending on your
-platform (instruction are on the website).
+We suggest you use the `micro:bit Python Editor <https://python.microbit.org>`_ when
+working through these tutorials.
 
-Mu works with Windows, OSX and Linux.
+Connect your micro:bit to your computer via a USB lead.
 
-Once Mu is installed connect your micro:bit to your computer via a USB lead.
+Write your script in the editor window and click the "Download" or "Flash" button to
+transfer it to the micro:bit.
 
-Write your script in the editor window and click the "Flash" button to transfer
-it to the micro:bit. If it doesn't work, make sure your micro:bit appears as
-a USB storage device in your file system explorer.
+If you have any problems with MicroPython or the editor, you can get support from the
+Micro:bit Educational Foundation team via `support.microbit.org <https://support.microbit.org>`_
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
Attempts to ease some of the confusion we have on support tickets where people are trying to open MicroPython projects in MakeCode.

- Change to make the Python Editor the default way of programming
- Mention that the code won't work in MakeCode