### PR TITLE
docs: fix missing pin methods and improve docs

### DIFF
--- a/docs/pin.rst
+++ b/docs/pin.rst
@@ -144,28 +144,27 @@ its own to that.
 
         Set the pin to high if ``value`` is 1, or to low, if it is 0.
 
-    .. py:method::set_pull(value)
+    .. py:method:: set_pull(value)
 
         Set the pull state to one of three possible values: ``pin.PULL_UP``,
         ``pin.PULL_DOWN`` or ``pin.NO_PULL`` (where ``pin`` is an instance of
         a pin). See below for discussion of default pull states.
 
-
-    .. py:method::get_pull()
+    .. py:method:: get_pull()
 
         Returns the pull configuration on a pin, which can be one of three 
         possible values: ``NO_PULL``, ``PULL_DOWN``, or ``PULL_UP``. These 
         are set using the ``set_pull()`` method or automatically configured 
         when a pin mode requires it.
 
-    .. py:method::get_mode()
+    .. py:method:: get_mode()
 
-        Returns the pin mode. When a pin is used for a specific function, like 
-        writing a digital value, or reading an analog value, the pin mode 
-        changes. Pins can have one of the following modes: ``MODE_UNUSED``, 
-        ``MODE_WRITE_ANALOG``, ``MODE_READ_DIGITAL``, ``MODE_WRITE_DIGITAL``, 
-        ``MODE_DISPLAY``, ``MODE_BUTTON``, ``MODE_MUSIC``, ``MODE_AUDIO_PLAY``,
-        ``MODE_TOUCH``, ``MODE_I2C``, ``MODE_SPI``.
+        Returns the pin mode. When a pin is used for a specific function, like
+        writing a digital value, or reading an analog value, the pin mode
+        changes. Pins can have one of the following modes: ``"unused"``,
+        ``"analog"``, ``"read_digital"``, ``"write_digital"``,
+        ``"display"``, ``"button"``, ``"music"``, ``"audio"``,
+        ``"touch"``, ``"i2c"``, ``"spi"``.
 
 
 .. py:class:: MicroBitAnalogDigitalPin
@@ -174,7 +173,6 @@ its own to that.
 
         Read the voltage applied to the pin, and return it as an integer
         between 0 (meaning 0V) and 1023 (meaning 3.3V).
-
 
     .. py:method:: write_analog(value)
 
@@ -191,14 +189,6 @@ its own to that.
 
         Set the period of the PWM signal being output to ``period`` in
         microseconds. The minimum valid value is 256µs.
-
-
-.. py:class:: MicroBitAnalogDigitalPin
-
-    .. py:method:: read_analog()
-
-        Read the voltage applied to the pin, and return it as an integer
-        between 0 (meaning 0V) and 1023 (meaning 3.3V).
 
 
 .. py:class:: MicroBitTouchPin


### PR DESCRIPTION
- fix missing space in directive that caused methods to be omitted.
- recast the get_mode() return values as their Python values rather than
  C names which aren't defined in Python.
- remove duplicate class definition for MicroBitAnalogDigitalPin.