### PR TITLE
docs: Remove outdated mention to display.image.

### DIFF
--- a/docs/microbit_micropython_api.rst
+++ b/docs/microbit_micropython_api.rst
@@ -108,12 +108,6 @@ Each of these pins are instances of the ``MicroBitPin`` class, which offers the 
 Images
 ------
 
-.. note::
-
-    You don't always need to create one of these yourself - you can access the
-    image shown on the display directly with `display.image`. `display.image`
-    is just an instance of `Image`, so you can use all of the same methods.
-
 Images API::
 
     # creates an empty 5x5 image


### PR DESCRIPTION
This was present in an old version of MicroPython and no longer available.