### PR TITLE
docs: Add note about possible 250kbit/sec radio rate in V2.

### DIFF
--- a/docs/radio.rst
+++ b/docs/radio.rst
@@ -36,12 +36,6 @@ Constants
 
     Constant used to indicate a throughput of 2 Mbit a second.
 
-.. py:attribute:: RATE_250KBIT
-
-    **Deprecated**.
-    This rate is possible with micro:bit V1, but it is not guaranteed to work
-    on V2, so it has been deprecated for compatibility reasons.
-
 
 Functions
 =========
@@ -93,6 +87,13 @@ Functions
     The ``data_rate`` (default=radio.RATE_1MBIT) indicates the speed at which
     data throughput takes place. Can be one of the following contants defined
     in the ``radio`` module : ``RATE_1MBIT`` or ``RATE_2MBIT``.
+
+    .. note::
+
+        A lower data rate of of 250kbit/sec is supported in micro:bit V1, and
+        may be possible with micro:bit V2, but it is not guaranteed to work on
+        all devices. To access this hidden feature for compatibility with V1
+        pass ``2`` to the ``data_rate`` argument.
 
     If ``config`` is not called then the defaults described above are assumed.
 


### PR DESCRIPTION
Follow up from https://github.com/bbcmicrobit/micropython/pull/731

In this case removing the `RATE_250KBIT` constant, that is no longer availabe in V2, and adding a note on how to configure the data_rate in the `config()` function.

Review deployment: https://microbit-micropython--744.org.readthedocs.build/en/744/radio.html

<img width="760" alt="image" src="https://user-images.githubusercontent.com/29712657/165150707-6a3f143c-950b-4de9-943e-08b55731f5e9.png">
