### PR TITLE
docs: Fix value range for accelerometer.set_range().

### DIFF
--- a/docs/accelerometer.rst
+++ b/docs/accelerometer.rst
@@ -7,7 +7,7 @@ This object gives you access to the on-board accelerometer.
 
 By default MicroPython sets the accelerometer range to +/- 2000 mg (``g`` being
 a unit of acceleration based on the standard gravity), which configures the
-maximum and minimum values returned by the acceleromter functions.
+maximum and minimum values returned by the accelerometer functions.
 The range can be changed via :func:`microbit.accelerometer.set_range`.
 
 The accelerometer also provides convenience functions for detecting gestures.
@@ -78,7 +78,7 @@ Functions
 .. py:function:: set_range(value)
 
     Set the accelerometer sensitivity range, in g (standard gravity), to the
-    closest values supported by the hardware, so it rounds to either ``1``,
+    closest values supported by the hardware, so it rounds to either
     ``2``, ``4``, or ``8`` g.
 
     :param value: New range for the accelerometer, an integer in ``g``.


### PR DESCRIPTION
The minimum values is 2:
- https://github.com/lancaster-university/microbit-dal/blob/602153e9199c28c08fd2561ce7b43bf64e9e7394/source/drivers/MMA8653.cpp#L42-L46
- https://github.com/lancaster-university/microbit-dal/blob/602153e9199c28c08fd2561ce7b43bf64e9e7394/source/drivers/FXOS8700.cpp#L42-L46
- https://github.com/lancaster-university/microbit-dal/blob/602153e9199c28c08fd2561ce7b43bf64e9e7394/source/drivers/LSM303Accelerometer.cpp#L42-L47
- https://github.com/lancaster-university/codal-core/blob/111fc68a06a6d0b05c3e8551890dc11f014c1dc9/source/drivers/LSM303Accelerometer.cpp#L45-L50