### PR TITLE
docs: Add missing `days` parameter to `microbit.run_every`.

### DIFF
--- a/docs/microbit.rst
+++ b/docs/microbit.rst
@@ -69,7 +69,7 @@ Functions
     :param n: An integer or floating point number indicating the number of
         milliseconds to wait.
 
-.. py:function:: run_every(callback, h=None, min=None, s=None, ms=None)
+.. py:function:: run_every(callback, days=None, h=None, min=None, s=None, ms=None)
 
     Schedule to run a function at the interval specified by the time arguments.
 
@@ -78,7 +78,7 @@ Functions
     * As a **Decorator** - placed on top of the function to schedule.
       For example::
 
-        @run_every(h=1, min=20, s=30, ms=50)
+        @run_every(days=1, h=1, min=20, s=30, ms=50)
         def my_function():
             # Do something here
 
@@ -89,7 +89,7 @@ Functions
             # Do something here
         run_every(my_function, s=30)
 
-    Each arguments corresponds to a different time unit and they are additive.
+    Each argument corresponds to a different time unit and they are additive.
     So ``run_every(min=1, s=30)`` schedules the callback every minute and
     a half.
 
@@ -97,6 +97,7 @@ Functions
     the function. To avoid this you can catch exceptions with ``try/except``.
 
     :param callback: Function to call at the provided interval.
+    :param days: Sets the days mark for the scheduling.
     :param h: Sets the hour mark for the scheduling.
     :param min: Sets the minute mark for the scheduling.
     :param s: Sets the second mark for the scheduling.


### PR DESCRIPTION
It was already implemented in MicroPython v2.1.0-beta.1, but missing from the docs.

Thanks @microbit-matt-hillsdon! 