### PR TITLE
docs: Update URL to download arm-none-eabi-gcc.

### DIFF
--- a/docs/devguide/flashfirmware.rst
+++ b/docs/devguide/flashfirmware.rst
@@ -14,7 +14,7 @@ Dependencies
 ------------
 
 - `CMake <https://cmake.org/>`_
-- `Arm GCC <https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads>`_
+- `Arm GCC <https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads>`_
 - `git <https://git-scm.com/>`_
 - `ninja <https://ninja-build.org/>`_
 - `python <https://www.python.org/downloads/>`_
@@ -87,7 +87,7 @@ The repository also contains a history of
 Dependencies
 ------------
 
-- `Arm GCC <https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads>`_
+- `Arm GCC <https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads>`_
 - `GCC <http://gcc.gnu.org/install/>`_
 - `CMake <https://cmake.org/>`_
 - `git <https://git-scm.com/>`_


### PR DESCRIPTION
The old URL still works, but it is not updated with the latest versions anymore.
Reported by @cleoqc in Mastodon, thanks!