### PR TITLE
docs: Add initial proposal for V2 recording & playback API. (WIP)

### DIFF
--- a/docs/audio.rst
+++ b/docs/audio.rst
@@ -12,7 +12,7 @@ a speaker to pin 0 and GND on the edge connector to hear the sounds.
 The ``audio`` module can be imported as ``import audio`` or accessed via
 the ``microbit`` module as ``microbit.audio``.
 
-There are three different kinds of audio sources that can be played using the
+There are five different kinds of audio sources that can be played using the
 :py:meth:`audio.play` function:
 
 1. `Built in sounds <#built-in-sounds-v2>`_ (**V2**),
@@ -268,7 +268,7 @@ AudioRecording
 --------------
 
 .. py:class::
-    AudioRecording(duration, rate=11_000)
+    AudioRecording(duration, rate=7812)
 
     The ``AudioRecording`` object contains audio data and the sampling rate
     associated to it.
@@ -305,6 +305,10 @@ AudioRecording
         Create an `AudioTrack <#audio.AudioTrack>`_ instance from a portion of
         the data in this ``AudioRecording`` instance.
 
+        Out-of-range values will be truncated to the recording limits.
+        If ``end_ms`` is lower than ``start_ms``, an empty track will be
+        created.
+
         :param start_ms: Where to start of the track in milliseconds.
         :param end_ms: The end of the track in milliseconds.
             If the default value of ``-1`` is provided it will end the track
@@ -335,7 +339,7 @@ AudioTrack
 
     When the input buffer has an associated rate (e.g. an ``AudioRecording``
     or ``AudioTrack``), the rate is copied. If the buffer object does not have
-    a rate, the default value of 11_000 is used.
+    a rate, the default value of 7812 is used.
 
     Changes to an ``AudioTrack`` rate won't affect the original source rate,
     so multiple instances pointing to the same buffer can have different

--- a/docs/audio.rst
+++ b/docs/audio.rst
@@ -72,6 +72,13 @@ Functions
 
     Stops all audio playback.
 
+.. py:function:: sound_level()
+
+    Get the sound pressure level produced by audio currently being played.
+
+    :return: A representation of the output sound pressure level in the
+        range 0 to 255.
+
 
 Built-in sounds **V2**
 ======================
@@ -251,10 +258,14 @@ AudioFrame
         During playback, increasing the sampling rate speeds up the sound
         and decreasing it slows it down.
 
+        :param sample_rate: The sample rate to set.
+
     .. py:function:: get_rate()
 
         (**V2 only**) Return the configured sampling rate for this
         ``AudioFrame`` instance.
+
+        :return: The configured sample rate.
 
     .. py:function:: copyfrom(other)
 
@@ -272,12 +283,13 @@ Technical Details
 
 The ``audio.play()`` function can consume an instance or iterable
 (sequence, like list or tuple, or generator) of ``AudioFrame`` instances,
-The ``AudioFrame`` default playback rate is 7812 Hz, and the output is a
-a PWM signal at 32.5 kHz.
+The ``AudioFrame`` default playback rate is 7812 Hz, and can be configured
+at any point with the ``AudioFrame.set_rate()`` method.
+The ``AudioFrame.set_rate()`` also works while the ``AudioFrame`` is being
+played, which will affect the playback speed.
 
 Each ``AudioFrame`` instance is 32 samples by default, but it can be
-configured to a different size via constructor and the
-``AudioFrame.set_rate()`` method.
+configured to a different size via constructor parameters.
 
 So, for example, playing 32 samples at 7812 Hz takes just over 4 milliseconds
 (1/7812.5 * 32 = 0.004096 = 4096 microseconds).

--- a/docs/audio.rst
+++ b/docs/audio.rst
@@ -12,18 +12,25 @@ a speaker to pin 0 and GND on the edge connector to hear the sounds.
 The ``audio`` module can be imported as ``import audio`` or accessed via
 the ``microbit`` module as ``microbit.audio``.
 
-There are three different kinds of audio sources that can be played using the
+There are four different kinds of audio sources that can be played using the
 :py:meth:`audio.play` function:
 
 1. `Built in sounds <#built-in-sounds-v2>`_ (**V2**),
    e.g. ``audio.play(Sound.HAPPY)``
+
 2. `Sound Effects <#sound-effects-v2>`_ (**V2**), a way to create custom sounds
    by configuring its parameters::
 
     my_effect = audio.SoundEffect(freq_start=400, freq_end=2500, duration=500)
     audio.play(my_effect)
 
-3. `Audio Frames <#audioframe>`_, an iterable (like a list or a generator)
+3. `AudioBuffer <#audiobuffer>`_ (**V2**), a generic buffer for audio that can
+   be used to record sound from the micro:bit V2 built-in microphone::
+
+    my_audio_buffer = microphone.record()
+    audio.play(my_audio_buffer)
+
+4. `Audio Frames <#audioframe>`_, an iterable (like a list or a generator)
    of Audio Frames, which are lists of 32 samples with values from 0 to 255::
 
     square_wave = audio.AudioFrame()
@@ -40,13 +47,16 @@ Functions
 
     Play the audio source to completion.
 
-    :param source: There are three types of data that can be used as a source:
+    :param source: There are four types of data that can be used as a source:
 
         - ``Sound``: The ``microbit`` module contains a list of
           built-in sounds, e.g. ``audio.play(Sound.TWINKLE)``. A full list can
           be found in the `Built in sounds <#built-in-sounds-v2>`_ section.
         - ``SoundEffect``: A sound effect, or an iterable of sound effects,
           created via the :py:meth:`audio.SoundEffect` class
+        - ``AudioBuffer``: An audio buffer, or an iterable of audio buffers,
+          created via the :py:meth:`audio.AudioBuffer` class or
+          :doc:`microphone.record() <microphone>` function
         - ``AudioFrame``: An iterable of ``AudioFrame`` instances as described
           in the `AudioFrame Technical Details <#id2>`_ section
 
@@ -214,6 +224,61 @@ Sound Effects Example
 
 .. include:: ../examples/soundeffects.py
     :code: python
+
+
+Audio Buffer **V2**
+===================
+
+.. py:class::
+    AudioBuffer(duration=3000, rate=11000)
+
+    Create a buffer to contain audio data and its sampling rate.
+
+    The sampling rate is configured via constructor or instance attribute,
+    and is used by the ``microphone.record_into()`` and
+    ``audio.play()`` functions to configure the recording and playback rates.
+
+    For audio recording, reducing the number of samples recorded per second
+    will reduce the size of the data buffer, but also reduce the sound quality.
+    And increasing the sampling rate increases the buffer size and sound
+    quality.
+
+    For audio playback, reducing the sampling rate compared with the recording
+    rate, will slow down the audio. And increasing the playback rate
+    will speed it up.
+
+    The size of the buffer will be determined by the samples per second
+    and the ``duration`` configured when creating a new instance.
+
+    :param duration: Indicates in milliseconds, how much sound data the buffer
+        can contained at the configured ``data_rate``.
+    :param rate: Sampling rate of for the data in the buffer. This value is
+        used for recording and playback, and can be edited as an attribute.
+
+    .. py:function:: copy()
+
+        :returns: A copy of the Audio Buffer.
+
+    .. py:attribute:: rate
+
+        The sampling rate for the data inside the buffer.
+        TODO: Indicate range of valid values here.
+
+Audio Buffer Example
+--------------------
+
+::
+
+    my_buffer = audio.AudioBuffer(duration=5000)
+    microphone.record_into(my_buffer)
+    audio.play(my_buffer)
+
+    # A smaller buffer can be generated with the same duration by using
+    # a lower sampling rate
+    smaller_buffer = audio.AudioBuffer(duration=5000, rate=5500)
+    microphone.record_into(my_buffer)
+    audio.play(my_buffer)
+
 
 AudioFrame
 ==========

--- a/docs/audio.rst
+++ b/docs/audio.rst
@@ -72,13 +72,6 @@ Functions
 
     Stops all audio playback.
 
-.. py:function:: set_rate(sample_rate)
-
-    Changes the sampling rate of ``AudioFrame`` playback.
-    The default playback rate is 7812 samples per second.
-    Decreasing the playback sampling rate results in slowed down sound, and
-    increasing it speeds it up.
-
 
 Built-in sounds **V2**
 ======================
@@ -230,12 +223,38 @@ AudioFrame
 ==========
 
 .. py:class::
-    AudioFrame(size=32)
+    AudioFrame(duration=-1, rate=7812)
 
-    An ``AudioFrame`` object is a list of samples each of which is an unsigned
+    An ``AudioFrame`` object is a list of samples, each of which is an unsigned
     byte (whole number between 0 and 255).
 
-    :param size: How many samples to contain in this instance.
+    The number of samples in an AudioFrame will depend on the
+    ``rate`` (number of samples per second) and ``duration`` parameters.
+    The total number of samples will always be a round up multiple of 32.
+
+    On micro:bit V1 the constructor does not take any arguments,
+    and an AudioFrame instance is always 32 bytes.
+
+    :param duration: (**V2**) Indicates how many milliseconds of audio this
+        instance can store.
+    :param rate: (**V2**) The sampling rate at which data will be stored
+        via the microphone, or played via the ``audio.play()`` function.
+
+    .. py:function:: set_rate(sample_rate)
+
+        (**V2 only**) Configure the sampling rate associated with the data
+        in the ``AudioFrame`` instance.
+
+        For recording from the microphone, increasing the sampling rate
+        increases the sound quality, but reduces the length of audio it
+        can store.
+        During playback, increasing the sampling rate speeds up the sound
+        and decreasing it slows it down.
+
+    .. py:function:: get_rate()
+
+        (**V2 only**) Return the configured sampling rate for this
+        ``AudioFrame`` instance.
 
     .. py:function:: copyfrom(other)
 
@@ -252,12 +271,13 @@ Technical Details
     It is just here in case you wanted to know how it works.
 
 The ``audio.play()`` function can consume an instance or iterable
-(sequence, like list or tuple, or generator) of ``AudioFrame`` instances.
-Its default playback rate is 7812 Hz, and uses linear interpolation to output
+(sequence, like list or tuple, or generator) of ``AudioFrame`` instances,
+The ``AudioFrame`` default playback rate is 7812 Hz, and the output is a
 a PWM signal at 32.5 kHz.
 
 Each ``AudioFrame`` instance is 32 samples by default, but it can be
-configured to a different size via constructor.
+configured to a different size via constructor and the
+``AudioFrame.set_rate()`` method.
 
 So, for example, playing 32 samples at 7812 Hz takes just over 4 milliseconds
 (1/7812.5 * 32 = 0.004096 = 4096 microseconds).

--- a/docs/microbit_micropython_api.rst
+++ b/docs/microbit_micropython_api.rst
@@ -109,9 +109,9 @@ The Microphone is accessed via the `microphone` object::
     # Returns a representation of the sound pressure level in the range 0 to 255.
     sound_level()
     # Record audio into a new `AudioRecording`
-    recording = record(duration, rate=7812)
+    recording = record(duration, rate=11_000)
     # Record audio into an existing `AudioRecording`
-    record_into(recording, rate=7812)
+    record_into(recording, wait=True)
     # Returns `True` if the microphone is currently recording audio
     is_recording()
     # Stop any active audio recording

--- a/docs/microbit_micropython_api.rst
+++ b/docs/microbit_micropython_api.rst
@@ -109,7 +109,7 @@ The Microphone is accessed via the `microphone` object::
     # Returns a representation of the sound pressure level in the range 0 to 255.
     sound_level()
     # Record audio into a new `AudioRecording`
-    recording = record(duration, rate=11_000)
+    recording = record(duration, rate=7812)
     # Record audio into an existing `AudioRecording`
     record_into(recording, wait=True)
     # Returns `True` if the microphone is currently recording audio

--- a/docs/microbit_micropython_api.rst
+++ b/docs/microbit_micropython_api.rst
@@ -108,6 +108,16 @@ The Microphone is accessed via the `microphone` object::
     set_threshold(128)
     # Returns a representation of the sound pressure level in the range 0 to 255.
     sound_level()
+    # Record audio into a new `AudioFrame`
+    record(duration, rate=7812)
+    # Record audio into an existing `AudioFrame`
+    record_into(buffer, rate=7812)
+    # Returns `True` if the microphone is currently recording audio
+    is_recording()
+    # Stop any active audio recording
+    stop()
+    # Set the microphone sensitivity (also referred as gain)
+    set_sensitivity(microphone.SENSITIVITY_MEDIUM)
 
 Pins
 ----

--- a/docs/microbit_micropython_api.rst
+++ b/docs/microbit_micropython_api.rst
@@ -108,10 +108,10 @@ The Microphone is accessed via the `microphone` object::
     set_threshold(128)
     # Returns a representation of the sound pressure level in the range 0 to 255.
     sound_level()
-    # Record audio into a new `AudioFrame`
-    record(duration, rate=7812)
-    # Record audio into an existing `AudioFrame`
-    record_into(buffer, rate=7812)
+    # Record audio into a new `AudioRecording`
+    recording = record(duration, rate=7812)
+    # Record audio into an existing `AudioRecording`
+    record_into(recording, rate=7812)
     # Returns `True` if the microphone is currently recording audio
     is_recording()
     # Stop any active audio recording

--- a/docs/microphone.rst
+++ b/docs/microphone.rst
@@ -36,12 +36,12 @@ then be played with the ``audio.play()`` function.
 
 Audio sampling is the process of converting sound into a digital format.
 To do this, the microphone takes samples of the sound waves at regular
-intervals. How many samples are recorded per second is known as the
+intervals. The number of samples recorded per second is known as the
 "sampling rate", so recording at a higher sampling rate increases the sound
-quality, but as more samples are saved, it also takes more memory.
+quality, but as more samples are saved, it also consumes more memory.
 
 The microphone sampling rate can be configured during sound recording via
-the ``rate`` argument in the ``record()`` and ``record_into()`` functions.
+the ``AudioFrame.rate()`` method functions.
 
 At the other side, the audio playback sampling rate indicates how many samples
 are played per second. So if audio is played back with a higher sampling rate
@@ -56,24 +56,22 @@ increased or decreased? Let's try it out!::
 
     from microbit import *
 
-    RECORDING_SAMPLING_RATE = 11000
-
     while True:
         if pin_logo.is_touched():
             # Record and play back at the same rate
-            my_recording = microphone.record(duration=3000, rate=RECORDING_SAMPLING_RATE)
+            my_recording = microphone.record(duration=3000)
             audio.play(my_recording)
 
         if button_a.is_pressed():
             # Play back at half the sampling rate
-            my_recording = microphone.record(duration=3000, rate=RECORDING_SAMPLING_RATE)
-            audio.set_rate(RECORDING_SAMPLING_RATE / 2)
+            my_recording = microphone.record(duration=3000)
+            my_recording.set_rate(my_recording.get_rate() // 2)
             audio.play(my_recording)
 
         if button_b.is_pressed():
             # Play back at twice the sampling rate
-            my_recording = microphone.record(duration=3000, rate=RECORDING_SAMPLING_RATE)
-            audio.set_rate(RECORDING_SAMPLING_RATE * 2)
+            my_recording = microphone.record(duration=3000)
+            my_recording.set_rate(my_recording.get_rate() * 2)
             audio.play(my_recording)
 
         sleep(200)
@@ -141,10 +139,10 @@ Functions
 
     :return: A representation of the sound pressure level in the range 0 to 255.
 
-.. py:function:: record(duration=3000, rate=7812, wait=True)
+.. py:function:: record(duration=3000, rate=7812)
 
-    Record sound for the amount of time indicated by ``duration`` at the
-    sampling rate indicated by ``rate``.
+    Record sound into an ``AudioFrame`` for the amount of time indicated by
+    ``duration`` at the sampling rate indicated by ``rate``.
 
     The amount of memory consumed is directly related to the length of the
     recording and the sampling rate. The higher these values, the more memory
@@ -155,10 +153,8 @@ Functions
 
     If there isn't enough memory available a ``MemoryError`` will be raised.
 
-    :param duration: How much time to record in milliseconds.
+    :param duration: How long to record in milliseconds.
     :param rate: Number of samples to capture per second.
-    :param wait: When set to ``True`` it blocks until the recording is
-        done, if it is set to ``False`` it will run in the background.
     :returns: An ``AudioFrame`` with the sound samples.
 
 .. py:function:: record_into(buffer, rate=7812, wait=True)
@@ -264,11 +260,10 @@ An example of recording and playback with a display animation::
         "00000"
     )
 
-    RECORDING_RATE = 5500
-    RECORDING_SECONDS = 5
-    RECORDING_SIZE = RECORDING_RATE * RECORDING_SECONDS
+    RECORDING_RATE = 3906
+    RECORDING_MS = 5000
 
-    my_recording = audio.AudioBuffer(size=RECORDING_SIZE)
+    my_recording = audio.AudioBuffer(duration=RECORDING_MS, rate=RECORDING_RATE)
 
     while True:
         if button_a.is_pressed():

--- a/docs/microphone.rst
+++ b/docs/microphone.rst
@@ -141,7 +141,7 @@ Functions
 
     :return: A representation of the sound pressure level in the range 0 to 255.
 
-.. py:function:: record(duration, rate=7812)
+.. py:function:: record(duration, rate=11000)
 
     Record sound into an ``AudioRecording`` for the amount of time indicated by
     ``duration`` at the sampling rate indicated by ``rate``.

--- a/docs/microphone.rst
+++ b/docs/microphone.rst
@@ -141,7 +141,7 @@ Functions
 
     :return: A representation of the sound pressure level in the range 0 to 255.
 
-.. py:function:: record(duration, rate=11000)
+.. py:function:: record(duration, rate=7812)
 
     Record sound into an ``AudioRecording`` for the amount of time indicated by
     ``duration`` at the sampling rate indicated by ``rate``.
@@ -267,10 +267,8 @@ An example of recording and playback with a display animation::
         "00000"
     )
 
-    RECORDING_RATE = 3906
-    RECORDING_MS = 5000
-
-    my_recording = audio.AudioRecording(duration=RECORDING_MS, rate=RECORDING_RATE)
+    RECORDING_RATE = 7812   # The default sample rate
+    my_recording = audio.AudioRecording(duration=5000, rate=RECORDING_RATE)
 
     while True:
         if button_a.is_pressed():
@@ -283,7 +281,10 @@ An example of recording and playback with a display animation::
         if button_b.is_pressed():
             audio.play(clipped_recording, wait=False)
             while audio.is_playing():
-                x = accelerometer.get_x()
-                audio.set_rate(scale(x, (-1000, 1000), (2250, 11000)))
+                clipped_recording.set_rate(scale(
+                    accelerometer.get_x(),
+                    (-1000, 1000),
+                    (RECORDING_RATE // 2, RECORDING_RATE * 2)
+                ))
                 sleep(50)
         sleep(100)

--- a/docs/microphone.rst
+++ b/docs/microphone.rst
@@ -139,7 +139,7 @@ Functions
 
     :return: A representation of the sound pressure level in the range 0 to 255.
 
-.. py:function:: record(duration=3000, rate=7812)
+.. py:function:: record(duration, rate=7812)
 
     Record sound into an ``AudioFrame`` for the amount of time indicated by
     ``duration`` at the sampling rate indicated by ``rate``.
@@ -174,7 +174,7 @@ Functions
 
 .. py:function:: stop_recording()
 
-    Stops an a recording running in the background.
+    Stops a recording running in the background.
 
 .. py:function:: set_sensitivity(gain)
 


### PR DESCRIPTION
Docs preview:
- https://microbit-micropython--791.org.readthedocs.build/en/791/audio.html
- https://microbit-micropython--791.org.readthedocs.build/en/791/microphone.html

This initial proposal has been discussed in:
- https://github.com/microbit-foundation/micropython-microbit-v2/issues/49

But we have some open question that will likely result and a rework of some of this.

## Initial proposal

The initial proposal in this PR was to create a new `AudioBuffer` class to contain the audio data and sampling rate.
The `AudioBuffer.rate` property could then be used by `microphone.record()` and `audio.play()`  to configure recording and playback rates.
This was done to avoid introducing a new parameter to `audio.play()` to configure the sampling rate, when it could only work with a single type of sound input (as it might not be possible to change the rate of the SoundExpressions or AudioFrames).

### Disadvantages

However, changing the rate in a buffer type to change the playback rate in real-time is a bit awkward:

```python
my_recording = audio.AudioBuffer(duration=5000, rate=5500)
microphone.record_into(my_recording)
audio.play(my_recording, wait=False)
while audio.is_playing():
    x = accelerometer.get_x()
    my_recording.rate = scale(x, (-1000, 1000), (2250, 11000))
    sleep(50)
```

An alternative we considered was to have the playback sampling rate modified via the audio module itself:

```python
audio.play(my_recording, wait=False)
while audio.is_playing():
    x = accelerometer.get_x()
    audio.set_rate(scale(x, (-1000, 1000), (2250, 11000)))
    sleep(50)
```

However, this would have to set the same rate to everything played via the audio module, and Sound Expression have a different default rate (44K) than recordings (11K). So `audio.set_rate(22000)` should slow down Sound Expression and speed up recordings.

Alternatively, if we wanted to change the playback rate via the audio module, we could set a ratio instead. Something equivalent to `audio.set_speed(100%)` (with different semantics). But a disadvantage would be that it's removing some of math/physics learning opportunity to directly relate the sampling rate value with the effects that it has in playback speed. 

## Alternative proposal: bytearray as the buffer type

In this case a byte array would be returned by `microphone.record()` and used with`microphone.record_into()`.

As this data type does not include info about the rate, we depend on the `audio.play()` adding an extra argument that might not work with other sound types like Sound Expressions and Audio Frames.

However, we still have the issue of updating the playback rate in real time during playback, which means we might would have to use use a similar approach to the previously mentioned `audio.set_speed(100%)`:

```python
sound_in_byte_array = microphone.record(duration=3000, rate=5500)
audio.play(sound_in_byte_array, rate=5500 wait=False)
while audio.is_playing():
    x = accelerometer.get_x()
    audio.set_speed(scale(x, (-1000, 1000), (50, 200)))
    sleep(50)
```

```python
DURATION_SECONDS = 3
SAMPLE_RATE = 5500
recording = bytearray(DURATION_SECONDS * SAMPLE_RATE)
microphone.record_into(recording, rate=SAMPLE_RATE)
audio.play(recording, rate=SAMPLE_RATE)
```

## Alternative proposal: AudioFrames as the buffer type

This would be the same as the bytearray proposal, but using the existing AudioFrames instead.

We might need to tweak the AudioFrame class to let us user larger buffers, as the default is 32 samples. As `audio.play()` can consume an iterable as well, we would need to figure out a good balance between AudioFrame size and number of AudioFrames in a recording buffer.
