### PR TITLE
docs: Fix issue in readthedocs builds.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 sphinx<8
-sphinx_rtd_theme<2
+sphinx_rtd_theme>=1,<2


### PR DESCRIPTION
Somehow due to some dependency conflict resolution the Read The Docs build pipeline ended up installing v0.5 of the rtd sphinx theme instead of a newer version, which was somehow incompatible with the newer sphinx releases.

```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/microbit-micropython/envs/latest/lib/python3.11/site-packages/sphinx/builders/html/__init__.py", line 1120, in handle_page
    output = self.templates.render(templatename, ctx)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/microbit-micropython/envs/latest/lib/python3.11/site-packages/readthedocs_ext/readthedocs.py", line 181, in rtd_render
    content = old_render(template, render_context)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/microbit-micropython/envs/latest/lib/python3.11/site-packages/sphinx/jinja2glue.py", line 200, in render
    return self.environment.get_template(template).render(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/microbit-micropython/envs/latest/lib/python3.11/site-packages/jinja2/environment.py", line 1304, in render
    self.environment.handle_exception()
  File "/home/docs/checkouts/readthedocs.org/user_builds/microbit-micropython/envs/latest/lib/python3.11/site-packages/jinja2/environment.py", line 939, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/home/docs/checkouts/readthedocs.org/user_builds/microbit-micropython/envs/latest/lib/python3.11/site-packages/sphinx/themes/basic/page.html", line 10, in top-level template code
    {%- extends "layout.html" %}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/microbit-micropython/envs/latest/lib/python3.11/site-packages/sphinx_rtd_theme/layout.html", line 23, in top-level template code
    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
    ^^^^^^^^^^^^^^^^^^^^^^^^^
jinja2.exceptions.UndefinedError: 'style' is undefined

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/microbit-micropython/envs/latest/lib/python3.11/site-packages/sphinx/cmd/build.py", line 337, in build_main
    app.build(args.force_all, args.filenames)
  File "/home/docs/checkouts/readthedocs.org/user_builds/microbit-micropython/envs/latest/lib/python3.11/site-packages/sphinx/application.py", line 378, in build
    self.builder.build_update()
  File "/home/docs/checkouts/readthedocs.org/user_builds/microbit-micropython/envs/latest/lib/python3.11/site-packages/sphinx/builders/__init__.py", line 297, in build_update
    self.build(to_build,
  File "/home/docs/checkouts/readthedocs.org/user_builds/microbit-micropython/envs/latest/lib/python3.11/site-packages/sphinx/builders/__init__.py", line 367, in build
    self.write(docnames, list(updated_docnames), method)
  File "/home/docs/checkouts/readthedocs.org/user_builds/microbit-micropython/envs/latest/lib/python3.11/site-packages/sphinx/builders/__init__.py", line 614, in write
    self._write_serial(sorted(docnames))
  File "/home/docs/checkouts/readthedocs.org/user_builds/microbit-micropython/envs/latest/lib/python3.11/site-packages/sphinx/builders/__init__.py", line 624, in _write_serial
    self.write_doc(docname, doctree)
  File "/home/docs/checkouts/readthedocs.org/user_builds/microbit-micropython/envs/latest/lib/python3.11/site-packages/sphinx/builders/html/__init__.py", line 666, in write_doc
    self.handle_page(docname, ctx, event_arg=doctree)
  File "/home/docs/checkouts/readthedocs.org/user_builds/microbit-micropython/envs/latest/lib/python3.11/site-packages/sphinx/builders/html/__init__.py", line 1127, in handle_page
    raise ThemeError(__("An error happened in rendering the page %s.\nReason: %r") %
sphinx.errors.ThemeError: An error happened in rendering the page accelerometer.
Reason: UndefinedError("'style' is undefined")

Theme error:
An error happened in rendering the page accelerometer.
Reason: UndefinedError("'style' is undefined")
```